### PR TITLE
feat(template): add iosv-eigrp-stub with EIGRP stub connected summary

### DIFF
--- a/src/topogen/templates/iosv-eigrp-stub.jinja2
+++ b/src/topogen/templates/iosv-eigrp-stub.jinja2
@@ -1,0 +1,51 @@
+hostname {{ node.hostname }}
+!
+service timestamps debug datetime msec
+service timestamps log datetime msec
+no service password-encryption
+no service config
+enable password {{ config.password }}
+ip classless
+ip subnet-zero
+ip domain lookup
+ip name-server {{ config.nameserver }}
+ip domain name {{ config.domainname }}
+crypto key generate rsa modulus 2048
+ip ssh version 2
+ip ssh server algorithm authentication password
+username {{ config.username }} privilege 15 secret {{ config.password }}
+cdp run
+!
+{%- if origin %}
+ip route 0.0.0.0 0.0.0.0 {{ origin.ip }}
+!
+{%- endif %}
+int Loopback0
+    ip address {{ node.loopback.ip }} {{ node.loopback.netmask }}
+!
+router eigrp 100
+    passive-interface Loopback0
+    network 10.10.0.0 0.0.255.255
+    network 10.20.0.0 0.0.255.255
+    no auto-summary
+    eigrp stub connected summary
+!
+{%- for iface in node.interfaces %}
+interface GigabitEthernet0/{{ loop.index0 }}
+    {%- if iface.description %}
+    description {{ iface.description }}
+    {%- endif %}
+    ip address {{ iface.address.ip }} {{ iface.address.netmask }}
+    cdp enable
+    no shutdown
+!
+{%- endfor %}
+line vty 0 4
+    transport input ssh telnet
+    exec-timeout 720 0
+    login local
+line con 0
+    password {{ config.password }}
+    exec-timeout 0 0
+!
+end


### PR DESCRIPTION
Summary
Adds IOSv template enabling EIGRP stub on leaf routers.
Motivation
Generate large flat labs where leaves advertise only connected/summary routes.
Changes
New: src/topogen/templates/iosv-eigrp-stub.jinja2
Line: eigrp stub connected summary under router eigrp 100
Docs (optional): README “Templates” + example; CHANGES.md Unreleased entry
How to test
topogen --list-templates → shows iosv-eigrp-stub
topogen --cml-version 0.3.0 -L "TestStub-2" -T iosv-eigrp-stub --device-template iosv -m flat --flat-group-size 2 --offline-yaml test-stub-2.yaml 2
Verify YAML/config contains “eigrp stub connected summary”
Risks/Notes
No behavior change to default templates; opt-in via -T iosv-eigrp-stub