### PR TITLE
docs: note how to refresh installed topogen version metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Alternatively, use Astral/uv:
    run with `uv run`)
 4. install using `uv sync --frozen`
 
+If `topogen -v` (or the generated lab description) shows an older version than this repo, reinstall the package in editable mode to refresh the installed package metadata:
+
+```powershell
+python -m pip install -e .
+```
+
 If the Networkx mode (`--mode nx`) should be used, then the following
 command is required instead to install SciPy and NumPy dependencies: `uv sync
 --all-extras --dev --frozen`


### PR DESCRIPTION
## Summary
Document how to refresh the installed TopoGen version metadata when `topogen -v` (or lab descriptions) show a stale version.

## Change
- README: add note recommending `python -m pip install -e .` to refresh installed package metadata/version.

## Why
TopoGen reads `__version__` from installed package metadata (`importlib.metadata`), so updating the environment install is required after version bumps.