### PR TITLE
feat(dmvpn): add multi-hub support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,16 @@ This file lists changes.
     - nodes argument is the number of spokes (R1 is hub; R2.. are spokes)
     - supports `--dmvpn-phase`, `--dmvpn-routing`, `--dmvpn-security`, `--dmvpn-nbma-cidr`, `--dmvpn-tunnel-cidr`
     - templates: `iosv-dmvpn` and `csr-dmvpn`
+  - feat(dmvpn): support multi-hub DMVPN
+    - select hub router numbers with `--dmvpn-hubs` (e.g., `1,21,41`)
+    - when `--dmvpn-hubs` is set, `nodes` is interpreted as total routers (R1..R<nodes>)
+    - spokes configure NHRP mappings and NHS entries for all hubs
+  - feat(dmvpn): add DMVPN tunnel key option `--dmvpn-tunnel-key` (default: 10)
+  - feat(offline): fail if `--offline-yaml FILE` already exists (no-clobber by default)
+    - overwrite explicitly with `--overwrite`
+  - feat(dmvpn): scale offline DMVPN NBMA segment using a flat-style unmanaged switch fabric (core + access switches)
+    - uses `--flat-group-size` to control routers per access switch
+    - offline YAML layout matches `flat` / `flat-pair` placement style
   - feat(gui): add optional Gooey GUI (`topogen-gui`) and `topogen[gui]` extra
     - GUI-only: template dropdown and common device-template dropdown
     - GUI-only: clearer offline/online YAML file labels and file-save pickers

--- a/src/topogen/templates/csr-dmvpn.jinja2
+++ b/src/topogen/templates/csr-dmvpn.jinja2
@@ -30,24 +30,32 @@ interface GigabitEthernet1
  ip address {{ ns.nbma.ip }} {{ ns.nbma.netmask }}
  no shutdown
 !
+interface Loopback0
+ ip address {{ node.loopback.ip }} {{ node.loopback.netmask }}
+!
 interface Tunnel0
  ip address {{ ns.tun.ip }} {{ ns.tun.netmask }}
  no ip redirects
  tunnel source GigabitEthernet1
+ tunnel key {{ dmvpn_tunnel_key }}
  tunnel mode gre multipoint
  ip nhrp network-id 10
 {%- if is_hub %}
  ip nhrp redirect
  no ip split-horizon eigrp 100
 {%- else %}
- ip nhrp map {{ hub_tunnel_ip }} {{ hub_nbma_ip }}
- ip nhrp map multicast {{ hub_nbma_ip }}
- ip nhrp nhs {{ hub_tunnel_ip }}
+{%- for hub in hub_info %}
+ ip nhrp map {{ hub.hub_tunnel_ip }} {{ hub.hub_nbma_ip }}
+ ip nhrp map multicast {{ hub.hub_nbma_ip }}
+ ip nhrp nhs {{ hub.hub_tunnel_ip }}
+{%- endfor %}
 {%- endif %}
 !
 router eigrp 100
  network {{ ns.tun.ip }} 0.0.0.0
+ network {{ node.loopback.ip }} 0.0.0.0
  passive-interface default
+ passive-interface GigabitEthernet1
  no passive-interface Tunnel0
 !
 line vty 0 4

--- a/src/topogen/templates/iosv-dmvpn.jinja2
+++ b/src/topogen/templates/iosv-dmvpn.jinja2
@@ -30,24 +30,32 @@ interface GigabitEthernet0/0
  ip address {{ ns.nbma.ip }} {{ ns.nbma.netmask }}
  no shutdown
 !
+int Loopback0
+ ip address {{ node.loopback.ip }} {{ node.loopback.netmask }}
+!
 interface Tunnel0
  ip address {{ ns.tun.ip }} {{ ns.tun.netmask }}
  no ip redirects
  tunnel source GigabitEthernet0/0
+ tunnel key {{ dmvpn_tunnel_key }}
  tunnel mode gre multipoint
  ip nhrp network-id 10
 {%- if is_hub %}
  ip nhrp redirect
  no ip split-horizon eigrp 100
 {%- else %}
- ip nhrp map {{ hub_tunnel_ip }} {{ hub_nbma_ip }}
- ip nhrp map multicast {{ hub_nbma_ip }}
- ip nhrp nhs {{ hub_tunnel_ip }}
+{%- for hub in hub_info %}
+ ip nhrp map {{ hub.hub_tunnel_ip }} {{ hub.hub_nbma_ip }}
+ ip nhrp map multicast {{ hub.hub_nbma_ip }}
+ ip nhrp nhs {{ hub.hub_tunnel_ip }}
+{%- endfor %}
 {%- endif %}
 !
 router eigrp 100
  network {{ ns.tun.ip }} 0.0.0.0
+ network {{ node.loopback.ip }} 0.0.0.0
  passive-interface default
+ passive-interface GigabitEthernet0/0
  no passive-interface Tunnel0
 !
 line vty 0 4


### PR DESCRIPTION
What this PR does
- Adds DMVPN multi-hub support to TopoGen.

Why
- Enables generating configs/topologies that include multiple DMVPN hubs.

Key changes
- DMVPN templates updated (CSR and IOSv)
- Rendering logic updated for multi-hub output
- GUI/main flow updated to support the new DMVPN options
- Docs updated (README + CHANGES)

How to test
- Generate configs for a topology with 3 hubs and at least 1 spoke
- Verify output includes expected tunnel/NHRP sections for each hub
- (Optional) Validate generated configs load on target platforms (CSR/IOSv)

Notes / limitations
- (Add any current limits you know, e.g., “tested with 3 hubs only”)