### PR TITLE
feat(dmvpn): add flat-pair underlay + clarify node semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ There are three modes available right now:
   - Default behavior: `nodes` is the number of spokes (R1 is hub; R2.. are spokes).
   - Multi-hub: use `--dmvpn-hubs` to specify hub router numbers (e.g., `1,21,41`).
     - When `--dmvpn-hubs` is set, `nodes` is interpreted as total routers (`R1..R<nodes>`).
+  - Underlay selection: use `--dmvpn-underlay` to choose the underlay model.
+    - `flat` (default): DMVPN routers attach to a flat L2 fabric.
+    - `flat-pair`: `nodes` is the total router count in the lab (`R1..R<nodes>`).
+      - Odd routers (`R1,R3,R5,...`): DMVPN overlay routers (hubs + spokes) (Tunnel0 + NHRP + routing).
+      - Even routers (`R2,R4,R6,...`): non-DMVPN pair partners (no Tunnel0/NHRP).
+      - Spokes are the odd routers not selected as hubs; this is always derived from `nodes`.
   - Optional: set `--dmvpn-tunnel-key` to configure a GRE tunnel key (default: 10).
   - Defaults:
     - NBMA: `10.10.0.0/16` (router WAN on slot 0)
@@ -274,6 +280,18 @@ topogen --cml-version 0.3.0 -m dmvpn -T csr-dmvpn --device-template csr1000v `
   -L "IOSXE-DMVPN-3H-P2-EIGRP-N63" `
   --offline-yaml out\IOSXE-DMVPN-3H-P2-EIGRP-N63.yaml `
   --dmvpn-hubs 1,21,41 63
+```
+
+- Offline YAML (DMVPN flat-pair, IOSv): 314 routers total (`R1..R314`). Odd routers participate in the DMVPN overlay (hubs + spokes).
+
+```powershell
+topogen -m dmvpn --dmvpn-underlay flat-pair -T iosv-dmvpn --device-template iosv -L IOSV-DMVPN-FLAT-PAIR-EIGRP-N314 --offline-yaml out\IOSV-DMVPN-FLAT-PAIR-EIGRP-N314.yaml --overwrite 314
+```
+
+- Offline YAML (DMVPN flat-pair, IOS-XE): 314 routers total (`R1..R314`). Odd routers participate in the DMVPN overlay (hubs + spokes).
+
+```powershell
+topogen -m dmvpn --dmvpn-underlay flat-pair -T csr-dmvpn --device-template csr1000v -L IOSXE-DMVPN-FLAT-PAIR-EIGRP-N314 --offline-yaml out\IOSXE-DMVPN-FLAT-PAIR-EIGRP-N314.yaml --overwrite 314
 ```
 
 - Online (controller):

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,87 @@
+# TODO
+
+This file tracks in-progress work and future ideas for TopoGen.
+
+## Conventions
+
+- Offline YAML output files should be written under `out/`.
+- `out/` is in `.gitignore`.
+- Prefer filename = lab name:
+  - Lab name: `IOSXE-DMVPN-FLAT-PAIR-3H-P2-EIGRP-N63`
+  - Offline YAML: `out\IOSXE-DMVPN-FLAT-PAIR-3H-P2-EIGRP-N63.yaml`
+
+- TODO buckets (to avoid confusion):
+  - `## Current work` = items for the feature currently being worked on.
+  - `## Future ideas` = new ideas not being worked on yet.
+  - `## Promote to Issues` = issue-worthy items that should become GitHub Issues when running the workflow.
+
+- When asking an LLM to add something, prefer:
+  - "Add to Current work: ..." or "Add to Future ideas: ..." or "Promote to Issues: ..."
+
+## Current work
+
+- [ ] Validate runtime behavior in CML for DMVPN underlay `flat-pair`:
+  - odd routers are DMVPN endpoints (Tunnel0/NHRP)
+  - even routers are EIGRP-only
+  - odd router NBMA interface is passive for EIGRP (no neighbors on Gi0/0)
+
+- [ ] Decide/implement least-astonishment semantics for DMVPN `--dmvpn-underlay flat-pair` node counts:
+  - whether `N` should mean total routers vs DMVPN endpoints
+  - or document the doubling behavior clearly
+
+- [ ] Commit/push PR for `feat/dmvpn-underlay` when ready.
+
+## Promote to Issues
+
+- [ ] (add issue-worthy items here)
+
+## Future ideas
+
+- [ ] (add ideas here)
+- [ ] Explore shareable, self-describing lab intents (example lab collection / “marketplace” concept)
+- [ ] Formalize serialized intent model (versioned `topogen:` schema embedded in lab YAML)
+- [ ] Support regenerating a lab from its embedded intent (`topogen regenerate lab.yaml`)
+- [ ] Make management plane a first-class intent (mgmt VRF, reserved interface, IPv4/IPv6 mode)
+- [ ] Emit machine-readable inventory alongside offline lab output
+- [ ] Add intent-level validation and least-astonishment checks before rendering
+- [ ] Support named intent profiles / presets for common lab patterns
+- [ ] Curate example offline labs using embedded intent (shareable / regeneratable lab collection)
+- [ ] Serialized Intent & Round-Trip Capability:
+  - Embed all generation parameters (topology mode, node count, addressing model) directly into the lab YAML under a `topogen:` metadata block.
+  - Implement a `topogen regenerate <file.yaml>` command that reads this metadata to deterministically recreate or update the lab.
+
+- [ ] Management Plane as First-Class Citizen:
+  - Automate a dedicated `management-vrf` configuration for `GigabitEthernet0/0` across all routers.
+  - Implement a deterministic IP calculator to assign static IPv4 and IPv6 management addresses based on Node ID.
+
+- [ ] Automation Inventory Emission:
+  - Generate an `inventory.json` (or `.yaml`/`.csv`) artifact during the offline generation phase.
+  - Include node names, management IPs, VRF names, and platform types to enable instant tool ingestion (Ansible, Nornir, Netmiko).
+
+- [ ] Offline Validation Sidecar:
+  - Emit a standalone `verify_connectivity.py` script alongside the lab YAML.
+  - Use the generated inventory to automatically test SSH reachability and protocol health (e.g., DMVPN status, OSPF neighbors) post-boot.
+
+- [ ] Gooey Round-Trip Integration:
+  - Add logic to prepopulate Gooey GUI fields by parsing the serialized intent from an existing lab YAML.
+
+- [ ] Add dedicated management VRF on Gi0/0 with deterministic IPv4/IPv6 addressing (medium effort).
+  - Why: Enables isolated mgmt plane for hundreds of routers; deterministic IPs (e.g., 172.16.0.{n+10}/24) make it predictable and unlock programmatic config via tools like Ansible; tie to --enable-mgmt-vrf flag and wire to a mgmt_switch.
+
+- [ ] Embed serialized intent in YAML (`topogen:` block) for regeneration workflows (medium effort).
+  - Why: Makes YAML the single source of truth with embedded params (mode, nodes, template, mgmt config); add `topogen regenerate lab.yaml` subcommand to unlock round-trip editing, GitOps, and easy tweaks without re-running full CLI.
+
+- [ ] Full DHCP + IPv6 on management plane (medium effort).
+  - Why: Layer DHCPv4/v6 via dnsmasq on DNS host with conditional templates for static vs. dynamic; pairs with mgmt VRF for "instant" auto-setup and dual-stack support in large labs.
+
+- [ ] Post-build automation hooks (low effort).
+  - Why: Add --post-hook flag for running scripts after generation (e.g., start lab, poll readiness, or run Ansible from inventory); unlocks "one command to fully configured lab" workflows.
+
+- [ ] Test unmanaged switches in all modes (flat, flat-pair, etc.) for port limits at 300+ nodes (medium effort).
+  - Why: Verify no overflows and add warnings/guardrails; builds confidence for huge-scale labs and document results in README for better user guidance.
+
+- [ ] Prepopulate Gooey GUI from existing YAML metadata (low effort).
+  - Why: Add "Load from YAML" file chooser to parse `topogen:` block and auto-fill fields; unlocks quick interactive edits/tweaks in GUI without retyping params.
+
+- [ ] Update README with topology diagrams and scale examples (low effort).
+  - Why: Add visuals for flat star vs. pair topologies and command examples (e.g., 300-node flat lab); makes the project more approachable and helps users understand scale capabilities.

--- a/src/topogen/templates/csr-dmvpn.jinja2
+++ b/src/topogen/templates/csr-dmvpn.jinja2
@@ -16,7 +16,7 @@ ip ssh server algorithm authentication password
 username {{ config.username }} privilege 15 secret {{ config.password }}
 cdp run
 !
-{%- set ns = namespace(nbma=None, tun=None) %}
+{%- set ns = namespace(nbma=None, tun=None, pair=None) %}
 {%- for iface in node.interfaces %}
 {%- if iface.description == "dmvpn nbma" %}
 {%- set ns.nbma = iface.address %}
@@ -24,12 +24,21 @@ cdp run
 {%- if iface.description == "dmvpn tunnel" %}
 {%- set ns.tun = iface.address %}
 {%- endif %}
+{%- if iface.description == "pair link" %}
+{%- set ns.pair = iface.address %}
+{%- endif %}
 {%- endfor %}
 !
 interface GigabitEthernet1
  ip address {{ ns.nbma.ip }} {{ ns.nbma.netmask }}
  no shutdown
 !
+{%- if ns.pair %}
+interface GigabitEthernet2
+ ip address {{ ns.pair.ip }} {{ ns.pair.netmask }}
+ no shutdown
+!
+{%- endif %}
 interface Loopback0
  ip address {{ node.loopback.ip }} {{ node.loopback.netmask }}
 !
@@ -54,9 +63,15 @@ interface Tunnel0
 router eigrp 100
  network {{ ns.tun.ip }} 0.0.0.0
  network {{ node.loopback.ip }} 0.0.0.0
+{%- if ns.pair %}
+ network {{ ns.pair.ip }} 0.0.0.0
+{%- endif %}
  passive-interface default
  passive-interface GigabitEthernet1
  no passive-interface Tunnel0
+{%- if ns.pair %}
+ no passive-interface GigabitEthernet2
+{%- endif %}
 !
 line vty 0 4
  transport input ssh telnet

--- a/src/topogen/templates/iosv-dmvpn.jinja2
+++ b/src/topogen/templates/iosv-dmvpn.jinja2
@@ -16,7 +16,7 @@ ip ssh server algorithm authentication password
 username {{ config.username }} privilege 15 secret {{ config.password }}
 cdp run
 !
-{%- set ns = namespace(nbma=None, tun=None) %}
+{%- set ns = namespace(nbma=None, tun=None, pair=None) %}
 {%- for iface in node.interfaces %}
 {%- if iface.description == "dmvpn nbma" %}
 {%- set ns.nbma = iface.address %}
@@ -24,12 +24,21 @@ cdp run
 {%- if iface.description == "dmvpn tunnel" %}
 {%- set ns.tun = iface.address %}
 {%- endif %}
+{%- if iface.description == "pair link" %}
+{%- set ns.pair = iface.address %}
+{%- endif %}
 {%- endfor %}
 !
 interface GigabitEthernet0/0
  ip address {{ ns.nbma.ip }} {{ ns.nbma.netmask }}
  no shutdown
 !
+{%- if ns.pair %}
+interface GigabitEthernet0/1
+ ip address {{ ns.pair.ip }} {{ ns.pair.netmask }}
+ no shutdown
+!
+{%- endif %}
 int Loopback0
  ip address {{ node.loopback.ip }} {{ node.loopback.netmask }}
 !
@@ -54,9 +63,15 @@ interface Tunnel0
 router eigrp 100
  network {{ ns.tun.ip }} 0.0.0.0
  network {{ node.loopback.ip }} 0.0.0.0
+{%- if ns.pair %}
+ network {{ ns.pair.ip }} 0.0.0.0
+{%- endif %}
  passive-interface default
  passive-interface GigabitEthernet0/0
  no passive-interface Tunnel0
+{%- if ns.pair %}
+ no passive-interface GigabitEthernet0/1
+{%- endif %}
 !
 line vty 0 4
  transport input ssh telnet


### PR DESCRIPTION
Summary
This PR adds DMVPN underlay mode flat-pair support and documents the intended node-count semantics so large labs (e.g. N314) are predictable.

Key changes
DMVPN --dmvpn-underlay flat-pair
nodes is interpreted as total routers (R1..R<nodes>).
Odd routers participate in the DMVPN overlay (hubs + spokes).
Even routers are non-DMVPN pair partners (no Tunnel0/NHRP).
Addressing behavior
Deterministic “router-number-based” addressing (including /16 rollover, e.g. R281 -> 10.10.1.25).
Templates
Updated DMVPN templates for IOSv and IOS-XE/CSR to support the flat-pair behavior.
Docs
README updated with explicit flat-pair semantics and N314 example commands (IOSv + IOS-XE) where lab name == offline YAML filename.
How to generate the large lab (examples)
IOSv:

powershell
topogen -m dmvpn --dmvpn-underlay flat-pair -T iosv-dmvpn --device-template iosv -L IOSV-DMVPN-FLAT-PAIR-EIGRP-N314 --offline-yaml out\IOSV-DMVPN-FLAT-PAIR-EIGRP-N314.yaml --overwrite 314
IOS-XE (CSR1000v):

powershell
topogen -m dmvpn --dmvpn-underlay flat-pair -T csr-dmvpn --device-template csr1000v -L IOSXE-DMVPN-FLAT-PAIR-EIGRP-N314 --offline-yaml out\IOSXE-DMVPN-FLAT-PAIR-EIGRP-N314.yaml --overwrite 314
Validation
Validated in CML with large-N labs:

Odd routers form DMVPN overlay (Tunnel0/NHRP present)
Even routers have no Tunnel0/NHRP
Addressing rollover confirmed (R241, R281 examples)