### PR TITLE
feat(dmvpn): IKEv2-PSK security + progress for DMVPN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,11 +21,19 @@ This file lists changes.
     - when `--dmvpn-hubs` is set, `nodes` is interpreted as total routers (R1..R<nodes>)
     - spokes configure NHRP mappings and NHS entries for all hubs
   - feat(dmvpn): add DMVPN tunnel key option `--dmvpn-tunnel-key` (default: 10)
+  - feat(dmvpn): add DMVPN IKEv2 PSK security profile
+    - enable with `--dmvpn-security ikev2-psk`
+    - provide shared PSK with `--dmvpn-psk <key>`
   - feat(offline): fail if `--offline-yaml FILE` already exists (no-clobber by default)
     - overwrite explicitly with `--overwrite`
+  - feat(progress): improve progress/completion visibility
+    - DMVPN online supports `--progress` (opt-in)
+    - DMVPN offline YAML supports `--progress` (opt-in)
+    - DMVPN offline YAML emits a visible "written to <file>" completion message at default loglevel
   - feat(dmvpn): scale offline DMVPN NBMA segment using a flat-style unmanaged switch fabric (core + access switches)
     - uses `--flat-group-size` to control routers per access switch
     - offline YAML layout matches `flat` / `flat-pair` placement style
+  - chore: reduce default `DMVPN-ping.tcl` sweep size to 10 for faster ad-hoc validation
   - feat(gui): add optional Gooey GUI (`topogen-gui`) and `topogen[gui]` extra
     - GUI-only: template dropdown and common device-template dropdown
     - GUI-only: clearer offline/online YAML file labels and file-save pickers

--- a/DMVPN-ping.tcl
+++ b/DMVPN-ping.tcl
@@ -1,5 +1,5 @@
 tclsh
-set max 250
+set max 10
 set base "10.20"
 
 for {set n 1} {$n <= $max} {incr n} {

--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ There are three modes available right now:
       - Even routers (`R2,R4,R6,...`): non-DMVPN pair partners (no Tunnel0/NHRP).
       - Spokes are the odd routers not selected as hubs; this is always derived from `nodes`.
   - Optional: set `--dmvpn-tunnel-key` to configure a GRE tunnel key (default: 10).
+  - Optional: set `--dmvpn-security ikev2-psk` to protect DMVPN with IKEv2+PSK.
+    - Requires `--dmvpn-psk <key>`.
+    - Uses IPsec transport mode with `tunnel protection ipsec profile ...` on `Tunnel0`.
   - Defaults:
     - NBMA: `10.10.0.0/16` (router WAN on slot 0)
     - Tunnel: `172.20.0.0/16` (Tunnel0)
@@ -301,6 +304,12 @@ topogen --cml-version 0.3.0 -m dmvpn -T csr-dmvpn --device-template csr1000v `
 
 ```powershell
 topogen -m dmvpn --dmvpn-underlay flat-pair -T iosv-dmvpn --device-template iosv --eigrp-stub -L IOSV-DMVPN-FLAT-PAIR-EIGRP-N314 --offline-yaml out\IOSV-DMVPN-FLAT-PAIR-EIGRP-N314.yaml --overwrite 314
+```
+
+- Offline YAML (DMVPN flat-pair, IOSv, VRF + IKEv2-PSK): 50 routers total, 3 hubs (`R1,R21,R41`).
+
+```powershell
+topogen --cml-version 0.3.0 -m dmvpn --dmvpn-underlay flat-pair -T iosv-dmvpn --device-template iosv --dmvpn-hubs 1,21,41 --dmvpn-phase 3 --dmvpn-routing eigrp --dmvpn-security ikev2-psk --dmvpn-psk "topogen123" --vrf --progress --offline-yaml out\IOSV-DMVPN-FLAT-PAIR-3H-P3-EIGRP-VRF-IPSEC-PSK-N50.yaml --overwrite 50
 ```
 
 - Offline YAML (DMVPN flat-pair, IOS-XE): 314 routers total (`R1..R314`). Odd routers participate in the DMVPN overlay (hubs + spokes).
@@ -408,6 +417,8 @@ By default, TopoGen will refuse to overwrite an existing offline YAML file.
 
 - If `FILE` already exists, the run fails with a clear error.
 - Use `--overwrite` to overwrite the existing file.
+
+Tip: add `--progress` to show a progress bar (opt-in).
 
 TopoGen does not pick an output filename automatically; you must provide one. We recommend `out/` for generated artifacts.
 

--- a/developer.md
+++ b/developer.md
@@ -339,6 +339,14 @@ If this file and the code disagree, treat the code as authoritative and update `
     - `VIRL2_PASS`
   - Uses `--insecure` if your controller TLS cert is not trusted.
 
+### Progress bars (`--progress`)
+
+- Progress bars are **opt-in** (they only show when `--progress` is provided).
+- Progress bars are supported for both:
+  - Offline YAML generation (local CPU work)
+  - Online controller lab creation (CML API calls + node/link creation)
+- Offline generation can complete very quickly even for large node counts (it does not boot routers).
+
 ## Gooey (GUI) notes
 
 TopoGen has an optional GUI wrapper that reuses the CLI.

--- a/src/topogen/main.py
+++ b/src/topogen/main.py
@@ -169,9 +169,16 @@ def create_argparser(parser_class=argparse.ArgumentParser):
         "--dmvpn-security",
         dest="dmvpn_security",
         type=str,
-        choices=("none",),
+        choices=("none", "ikev2-psk"),
         default="none",
         help='DMVPN security/profile, default "%(default)s"',
+    )
+    parser.add_argument(
+        "--dmvpn-psk",
+        dest="dmvpn_psk",
+        type=str,
+        default=None,
+        help="DMVPN IKEv2 pre-shared key (used when --dmvpn-security ikev2-psk)",
     )
     if is_gooey:
         parser.add_argument(
@@ -411,6 +418,11 @@ def main():
 
     try:
         args.dmvpn_hubs_list = parse_dmvpn_hubs(getattr(args, "dmvpn_hubs", None))
+
+        if args.mode == "dmvpn" and getattr(args, "dmvpn_security", "none") == "ikev2-psk":
+            psk = getattr(args, "dmvpn_psk", None)
+            if not psk or not str(psk).strip():
+                parser.error("--dmvpn-security ikev2-psk requires --dmvpn-psk <key>")
 
         # DMVPN flat-pair uses odd routers as DMVPN endpoints. If hubs are not
         # provided, default to the first 3 endpoint routers (R1,R3,R5), or fewer

--- a/src/topogen/templates/csr-dmvpn.jinja2
+++ b/src/topogen/templates/csr-dmvpn.jinja2
@@ -22,6 +22,36 @@ vrf definition {{ dmvpn_vrf }}
  exit-address-family
 !
 {%- endif %}
+{%- if dmvpn_security == "ikev2-psk" %}
+!
+crypto ikev2 proposal TOPGEN-PROP
+ encryption aes-cbc-256
+ integrity sha256
+ group 14
+!
+crypto ikev2 policy TOPGEN-POL
+ proposal TOPGEN-PROP
+!
+crypto ikev2 keyring TOPGEN-KR
+ peer ANY
+  address 0.0.0.0 0.0.0.0
+  pre-shared-key local {{ dmvpn_psk }}
+  pre-shared-key remote {{ dmvpn_psk }}
+!
+crypto ikev2 profile TOPGEN-IKEV2
+ match identity remote address 0.0.0.0 0.0.0.0
+ authentication remote pre-share
+ authentication local pre-share
+ keyring local TOPGEN-KR
+!
+crypto ipsec transform-set TOPGEN-TS esp-aes 256 esp-sha256-hmac
+ mode transport
+!
+crypto ipsec profile TOPGEN-IPSEC
+ set transform-set TOPGEN-TS
+ set ikev2-profile TOPGEN-IKEV2
+!
+{%- endif %}
 !
 {%- set ns = namespace(nbma=None, tun=None, pair=None) %}
 {%- for iface in node.interfaces %}
@@ -65,6 +95,9 @@ interface Tunnel0
  tunnel key {{ dmvpn_tunnel_key }}
  tunnel mode gre multipoint
  ip nhrp network-id 10
+{%- if dmvpn_security == "ikev2-psk" %}
+ tunnel protection ipsec profile TOPGEN-IPSEC
+{%- endif %}
 {%- if is_hub %}
 {%- if (dmvpn_phase|default(2)) == 3 %}
  ip nhrp redirect

--- a/src/topogen/templates/iosv-dmvpn.jinja2
+++ b/src/topogen/templates/iosv-dmvpn.jinja2
@@ -19,6 +19,36 @@ cdp run
 ip vrf {{ dmvpn_vrf }}
 !
 {%- endif %}
+{%- if dmvpn_security == "ikev2-psk" %}
+!
+crypto ikev2 proposal TOPGEN-PROP
+ encryption aes-cbc-256
+ integrity sha256
+ group 14
+!
+crypto ikev2 policy TOPGEN-POL
+ proposal TOPGEN-PROP
+!
+crypto ikev2 keyring TOPGEN-KR
+ peer ANY
+  address 0.0.0.0 0.0.0.0
+  pre-shared-key local {{ dmvpn_psk }}
+  pre-shared-key remote {{ dmvpn_psk }}
+!
+crypto ikev2 profile TOPGEN-IKEV2
+ match identity remote address 0.0.0.0 0.0.0.0
+ authentication remote pre-share
+ authentication local pre-share
+ keyring local TOPGEN-KR
+!
+crypto ipsec transform-set TOPGEN-TS esp-aes 256 esp-sha256-hmac
+ mode transport
+!
+crypto ipsec profile TOPGEN-IPSEC
+ set transform-set TOPGEN-TS
+ set ikev2-profile TOPGEN-IKEV2
+!
+{%- endif %}
 !
 {%- set ns = namespace(nbma=None, tun=None, pair=None) %}
 {%- for iface in node.interfaces %}
@@ -62,6 +92,9 @@ interface Tunnel0
   tunnel key {{ dmvpn_tunnel_key }}
   tunnel mode gre multipoint
  ip nhrp network-id 10
+{%- if dmvpn_security == "ikev2-psk" %}
+ tunnel protection ipsec profile TOPGEN-IPSEC
+{%- endif %}
 {%- if is_hub %}
 {%- if (dmvpn_phase|default(2)) == 3 %}
  ip nhrp redirect


### PR DESCRIPTION
## Summary
Adds DMVPN security option `ikev2-psk` with required `--dmvpn-psk` and renders IKEv2/IPsec (transport mode) for DMVPN templates (IOSv + CSR).

Also improves user feedback for large builds:
- DMVPN online progress bar support via `--progress`
- DMVPN offline YAML progress bar support via `--progress`
- Offline YAML completion message is visible at default loglevel

## CLI / Usage
Example (CSR1000v, DMVPN flat-pair, 3 hubs, VRF, IKEv2-PSK, offline):
```powershell
topogen --cml-version 0.3.0 -m dmvpn --dmvpn-underlay flat-pair -T csr-dmvpn --device-template csr1000v `
  -L "IOSXE-DMVPN-FLAT-PAIR-3H-P3-EIGRP-VRF-IPSEC-PSK-N60" `
  --dmvpn-hubs 1,21,41 --dmvpn-phase 3 --dmvpn-routing eigrp `
  --dmvpn-security ikev2-psk --dmvpn-psk "topogen123" `
  --vrf --progress `
  --offline-yaml out\IOSXE-DMVPN-FLAT-PAIR-3H-P3-EIGRP-VRF-IPSEC-PSK-N60.yaml --overwrite 60