### PR TITLE
feat(mgmt): add OOB mgmt network support for flat-pair

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 This file lists changes.
 
 - Unreleased
-  - feat(mgmt): add OOB management network support for flat mode
+  - feat(mgmt): add OOB management network support for flat and flat-pair modes
     - enable with `--mgmt`
     - creates `SWoob0` unmanaged switch (with `hide_links: true`) and connects all router mgmt interfaces
     - mgmt interface uses DHCP by default (slot 5: IOSv Gi0/5, CSR Gi5)

--- a/TODO.md
+++ b/TODO.md
@@ -27,10 +27,7 @@ This file tracks in-progress work and future ideas for TopoGen.
 
 ## Current work
 
-- [ ] Add OOB management network support for flat-pair mode
-  - reuse flat mgmt pattern (SWoob core + access switches)
-  - connect odd and even router mgmt interfaces to OOB switches
-  - pass mgmt/ntp context to templates
+- [ ] (add current work items here)
 
 ## Promote to Issues
 


### PR DESCRIPTION
### Summary
Adds dedicated out-of-band management network support to `flat-pair` mode, matching the existing `flat` mgmt behavior. Routers get a DHCP-based management interface in `Mgmt-vrf`, and optional NTP configuration works with the mgmt VRF.

### What changed
- **`flat-pair` offline YAML** now builds an OOB fabric:
  - `SWoob0` core + `SWoob1..N` access unmanaged switches
  - `hide_links: true` on OOB switches so mgmt links don’t clutter the diagram
  - Each router mgmt interface connects into the OOB fabric
- **Templates** receive `mgmt` + `ntp` context in flat-pair so configs include:
  - `Gi0/5` DHCP (IOSv) (CSR uses `Gi5` with correct slot mapping)
  - VRF default `Mgmt-vrf`
  - NTP server config (`--ntp`) with optional VRF handling
- **Naming cleanup**: core-network switches in offline YAML use `SW0/SW1..` (instead of `SWmgt*`), and OOB uses `SWoob*`.

### Test / Verification
Command used:
```powershell
topogen --cml-version 0.3.0 -L "Flat-Pair-Mgmt-IOSv" -T iosv-eigrp --device-template iosv -m flat-pair --flat-group-size 5 --mgmt --ntp 192.168.1.10 --progress --offline-yaml out\flat-pair-mgmt-iosv.yaml --overwrite 6
```

Validated in CML (example `R2`):
- `Gi0/5` received DHCP and is up/up
- `Mgmt-vrf` exists and is bound to `Gi0/5`
- NTP is synchronized to `192.168.1.10`

### Notes
- OOB and core switch grouping both use `--flat-group-size` so large topologies stay easy to navigate and consistent.

## Status
- **PR ready** (title + description prepared).