### PR TITLE
fix(dmvpn): fix OOB switch overflow in offline_dmvpn_flat_pair_yaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.2.4
-Date Modified: 2026-02-18
+Doc Version: v1.2.5
+Date Modified: 2026-02-19
 
 - Called by: Users checking release notes, package managers, documentation generators
 - Reads from: Developer commits, PR descriptions, completed TODO items
@@ -20,6 +20,8 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - fix(dmvpn): OOB switch overflow in `offline_dmvpn_flat_pair_yaml` — `num_oob_sw` was set to `num_access` (NBMA switch count, based on odd routers only), but OOB connects ALL routers; with large labs (e.g. 200 nodes, group=20) each OOB access switch got 40 routers + 1 uplink = 41 ports, exceeding the CML `unmanaged_switch` 32-port cap; fix: `num_oob_sw = ceil(total_routers / oob_group)` so OOB switches are sized by total router count
+    - Files: src/topogen/render.py (rev v1.0.10 → v1.0.11), CHANGES.md (rev v1.2.4 → v1.2.5)
   - fix(dmvpn): EEM CLIENT-PKI-SET-CLOCK and CLIENT-PKI-AUTHENTICATE timers increased from 90 s/95 s to 300 s/305 s to give CA-ROOT sufficient time to boot and start its PKI server before spoke enrollment attempts; if CA-ROOT is not reachable when the timer fires, manual `authc` is the workaround
     - Files: src/topogen/render.py (rev v1.0.9 → v1.0.10), CHANGES.md (rev v1.2.3 → v1.2.4)
   - fix(dmvpn): EEM applets now injected LAST in startup config (before final `end`), after all interface/routing/crypto sections — previously EEM applets were placed before the IKEv2/interface/routing sections, and each applet's closing `end` exits IOS-XE global config mode, causing everything after the first EEM `end` to be silently ignored at boot (interfaces never came up, no IPs assigned, no EIGRP/DMVPN)

--- a/src/topogen/render.py
+++ b/src/topogen/render.py
@@ -1,6 +1,6 @@
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.0.10
-# Date Modified: 2026-02-18
+# Doc Version: v1.0.11
+# Date Modified: 2026-02-19
 #
 # - Called by: src/topogen/main.py
 # - Reads from: Packaged templates, Config, env (VIRL2_*), models
@@ -2404,11 +2404,10 @@ class Renderer:
         num_oob_sw = 0
         oob_per_sw_counts: list[int] = []
         if enable_mgmt:
-            num_oob_sw = num_access  # Match the number of NBMA switches
-            # Precompute how many routers per OOB access switch
-            # In flat-pair, routers are paired (total_endpoints is the pair count)
-            # But we connect ALL routers to mgmt, so use total_routers
+            # OOB connects ALL routers (not just DMVPN endpoints), so size based on total_routers
             from math import ceil
+            num_oob_sw = ceil(total_routers / oob_group)
+            # Precompute how many routers per OOB access switch
             routers_per_oob = ceil(total_routers / num_oob_sw)
             for i in range(num_oob_sw):
                 start = i * routers_per_oob


### PR DESCRIPTION
num_oob_sw was set to num_access (NBMA switch count, sized for odd routers only), but OOB connects ALL routers. For 200-node lab with group=20: num_access=5, 200/5=40 routers/switch + 1 uplink = 41 ports, exceeding the CML unmanaged_switch 32-port cap. Fix: size num_oob_sw by total_routers so each OOB access switch gets at most group+1 ports.

Doc Version deltas:
  src/topogen/render.py: v1.0.10 → v1.0.11
  CHANGES.md: v1.2.4 → v1.2.5