### PR TITLE
feat(quiet): add -q/--quiet to suppress non-essential output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.2.6
+Doc Version: v1.2.7
 Date Modified: 2026-02-19
 
 - Called by: Users checking release notes, package managers, documentation generators
@@ -20,6 +20,9 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - feat(quiet): add `-q` / `--quiet` flag to suppress non-essential output
+    - When set, log level is forced to ERROR so only errors and final result are shown; useful for scripts and CI/CD
+    - Files: src/topogen/main.py (rev v1.1.3 → v1.1.4), CHANGES.md (rev v1.2.6 → v1.2.7), README.md (rev v1.4.5 → v1.4.6), DEVELOPER.md (rev v1.7.3 → v1.7.4), TODO.md (rev v1.6.3 → v1.6.4)
   - fix(online): pass VIRL2_URL, VIRL2_USER, VIRL2_PASS explicitly into ClientLibrary
     - TopoGen now reads env vars and passes url/username/password to virl2_client.ClientLibrary(); fixes "no env provided" when vars are set in PowerShell/shell before running topogen
     - Files: src/topogen/render.py (rev v1.0.11 → v1.0.12), CHANGES.md (rev v1.2.5 → v1.2.6)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md - this file!):
-Doc Version: v1.7.3
+Doc Version: v1.7.4
 Date Modified: 2026-02-19
 
 - Called by: Developers (new contributors, AI assistants), maintainers
@@ -913,7 +913,7 @@ Jinja2:
 
 ### `src/topogen/main.py`
 
-- **Doc Version:** v1.1.3
+- **Doc Version:** v1.1.4
 
 - **Called by**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.4.5
+Doc Version: v1.4.6
 Date Modified: 2026-02-19
 
 - Called by: Users (primary entry point), package managers (PyPI), GitHub viewers
@@ -340,6 +340,7 @@ There are three modes available right now:
     - **Important:** if you set `--dmvpn-security ikev2-pki` but omit `--pki`, TopoGen exits with an error.
     - **Note:** DMVPN with IKEv2 PKI is not yet validated; tunnels may not come up (IKEv2 SA / enrollment troubleshooting in progress).
   - Optional: `--archive` — enable config archive and `rundiff` alias on all IOS/IOS-XE routers in flat, flat-pair, and dmvpn modes (`archive` with `log config`, `path flash:`, `write-memory`). Omit to leave archive config out of generated configs.
+  - Optional: `-q` / `--quiet` — suppress INFO and WARNING; only errors and final result (useful for scripts and CI/CD).
   - Defaults:
     - NBMA: `10.10.0.0/16` (router WAN on slot 0)
     - Tunnel: `172.20.0.0/16` (Tunnel0)

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.6.3
+Doc Version: v1.6.4
 Date Modified: 2026-02-19
 
 - Called by: Developers planning features, LLMs adding work items, project management
@@ -250,11 +250,9 @@ Recent completions:
   - When: Implement when a CI/CD pipeline or automation script needs to consume the output programmatically.
   - Blast radius: render.py (4 offline write paths), no behavior change to existing log lines.
 
-- [ ] Add `--quiet` flag to suppress non-essential output (low effort).
-  - Why: When running in scripts or CI/CD, users may only want errors or the final artifact path, not progress/config warnings.
-  - Behavior: Suppress INFO and WARNING logs, only show ERROR and the final output line.
-  - Pairs well with: Machine-parsable artifact summary (above) for clean scripted workflows.
-  - Blast radius: main.py (argparse + log level config), no changes to render logic.
+- [x] Add `--quiet` flag to suppress non-essential output (low effort) (feat/quiet).
+  - Implemented: `-q` / `--quiet` forces log level to ERROR so only errors and final result are shown; useful for scripts and CI/CD.
+  - Blast radius: main.py (argparse + log level override), no changes to render logic.
 
 - [x] Add `--import` and `--import-yaml` flags for offline-to-CML workflow (medium effort).
   - Why: Currently there's no way to take an offline YAML and push it into CML without switching to online mode.

--- a/src/topogen/main.py
+++ b/src/topogen/main.py
@@ -1,5 +1,5 @@
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.3
+# Doc Version: v1.1.4
 # Date Modified: 2026-02-19
 #
 """
@@ -97,6 +97,12 @@ def create_argparser(parser_class=argparse.ArgumentParser):
         "--progress",
         action="store_true",
         help="show a progress bar",
+    )
+    config_settings.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="suppress non-essential output (INFO/WARN); only errors and final result",
     )
 
     parser.add_argument(
@@ -563,6 +569,8 @@ def main():
     # Default lab name: when generating offline YAML and user did not pass -L, use filename (no path, no extension); otherwise "topogen lab" (e.g. online).
     if getattr(args, "offline_yaml", None) and getattr(args, "labname", None) == "topogen lab":
         args.labname = os.path.splitext(os.path.basename(args.offline_yaml))[0]
+    if getattr(args, "quiet", False):
+        args.loglevel = "ERROR"
     setup_logging(args.loglevel)
 
     def parse_dmvpn_hubs(value: str | None) -> list[int] | None:


### PR DESCRIPTION
## Summary
Adds a `-q` / `--quiet` flag so scripts and CI/CD can run topogen with minimal output (only errors and final result).

## Behavior
- **Without `-q`:** Current behavior (INFO/WARN logs, e.g. config defaults, "Offline YAML written to ...").
- **With `-q`:** Log level is forced to ERROR; only errors and explicit final output are shown.

## Changes
- **main.py:** New `-q`/`--quiet` in config group; when set, `args.loglevel` is set to `"ERROR"` before `setup_logging()`.
- **Docs:** CHANGES (Unreleased), README (flag note), DEVELOPER (main.py rev), TODO (item marked done).

## Doc versions
- main.py: v1.1.3 → v1.1.4  
- CHANGES.md: v1.2.6 → v1.2.7  
- README.md: v1.4.5 → v1.4.6  
- DEVELOPER.md: v1.7.3 → v1.7.4  
- TODO.md: v1.6.3 → v1.6.4  

## Blast radius
main.py only (argparse + log level); no render or template changes.