### PR TITLE
docs: add smart_annotations (CML 2.8+) notes to TESTED and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.4.7
-Date Modified: 2026-02-19
+Doc Version: v1.4.8
+Date Modified: 2026-02-21
 
 - Called by: Users (primary entry point), package managers (PyPI), GitHub viewers
 - Reads from: None (documentation only)
@@ -300,6 +300,8 @@ configuration:
   -p, --progress        show a progress bar
 $
 ```
+
+Note: Generated offline YAML includes `smart_annotations: []`, a field introduced in CML 2.8. TopoGen has not been tested on CML versions earlier than 2.9. Import on CML 2.7 or older may fail if the parser rejects unknown fields.
 
 At a minimum, the amount of nodes to be created must be provided.
 

--- a/TESTED.md
+++ b/TESTED.md
@@ -2,8 +2,8 @@
 
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.1.1
-Date Modified: 2026-02-16
+Doc Version: v1.1.2
+Date Modified: 2026-02-21
 
 - Called by: Developers via DEVELOPER.md link, CI/CD systems for platform validation
 - Reads from: Manual observations from development/testing (AI-first documentation)
@@ -66,6 +66,9 @@ types-networkx >= 3.5.0.20250531
   - Note: PKI server requires IOS-XE 17.x+
 - **IOSv 15.9** - OSPF, EIGRP, DMVPN Phase 2
 - **ASAv 9.x** - IKEv2 VPN endpoints (observed in user labs)
+
+### smart_annotations (CML 2.8+)
+TopoGen offline YAML includes `smart_annotations: []` in all generated files (added with the intent/annotation feature). This field was introduced in CML 2.8. Behavior on CML versions earlier than 2.8 is unknown — older parsers may silently ignore the field or reject the import. Not tested on any version earlier than 2.9. Tested on CML 2.10 (not yet publicly available at time of writing). If you are running CML 2.7 or earlier and import fails, the `smart_annotations: []` line is the likely cause.
 
 ## Operating System
 


### PR DESCRIPTION
Document that TopoGen offline YAML includes `smart_annotations: []` (CML 2.8+). Older CML versions may ignore or reject this field on import.

**Changes:**
- **TESTED.md** (CML Environment): New subsection describing the field, CML 2.8 introduction, and that import on 2.7 or earlier may fail. Doc Version v1.1.1 → v1.1.2.
- **README.md**: Short note near `--cml-version` so users see the caveat when generating offline YAML. Doc Version v1.4.7 → v1.4.8.

**Doc Version:** TESTED.md v1.1.2, README.md v1.4.8