### PR TITLE
fix(flat): auto-scale coordinates in offline_flat_yaml and offline_fl…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.2.8
-Date Modified: 2026-02-20
+Doc Version: v1.2.9
+Date Modified: 2026-02-24
 
 - Called by: Users checking release notes, package managers, documentation generators
 - Reads from: Developer commits, PR descriptions, completed TODO items
@@ -20,6 +20,11 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - fix(flat): auto-scale x/y coordinates in `offline_flat_yaml` and `offline_flat_pair_yaml` so any node count and group size produces importable YAML without exceeding CML's 15000-coordinate limit
+    - Previously, switch x was computed as `(i+1) * distance * 3` with no upper bound; at 26 access switches (520 nodes, group=20) the last switch landed at x=15600 and CML rejected the import with a validation error
+    - Fix: compute `sw_step_x` and `router_step_y` scaled to `max_coord=15000` (same approach as the existing DMVPN renderer); all node placements are clamped with `min(max_coord, ...)`
+    - Users no longer need to manually tune `--flat-group-size` to avoid coordinate overflow; the layout adapts automatically
+    - Files: src/topogen/render.py (rev v1.0.13 → v1.0.14), CHANGES.md (rev v1.2.8 → v1.2.9), README.md (rev v1.4.8 → v1.4.9)
   - docs(pki): add PKI.md — single reference for TopoGen PKI (flags, CA-ROOT, clients, EEM applets, known issues, auto-deploy certs, troubleshooting); add PKI.md to README documentation map
     - Files: PKI.md (new, rev v1.0.0), README.md (rev v1.4.7 → v1.4.8), CHANGES.md (rev v1.2.7 → v1.2.8)
   - feat(quiet): add `-q` / `--quiet` flag to suppress non-essential output

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.4.8
-Date Modified: 2026-02-21
+Doc Version: v1.4.9
+Date Modified: 2026-02-24
 
 - Called by: Users (primary entry point), package managers (PyPI), GitHub viewers
 - Reads from: None (documentation only)
@@ -515,6 +515,7 @@ Defaults are safe for large labs (e.g., 300 nodes with `--flat-group-size 20` â†
 
 Assumptions and caveats:
 
+- **Coordinate layout is automatic.** TopoGen scales node x/y positions to always stay within CML's 15,000-coordinate limit, regardless of node count or `--flat-group-size`. You do not need to manually adjust group size to avoid import errors.
 - The guardrails assume the `unmanaged_switch` node definition has roughly 32 usable ports.
 - Custom node definitions/images (including customized unmanaged switch or different router images) may change interface counts, labels, or slot allocation. The guardrails do not auto-detect such customizations.
 - In generated offline YAML, unmanaged switch interfaces are labeled `portN`; the CML UI may present different labels.

--- a/src/topogen/render.py
+++ b/src/topogen/render.py
@@ -1,5 +1,5 @@
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.0.13
+# Doc Version: v1.0.14
 # Date Modified: 2026-02-23
 #
 # - Called by: src/topogen/main.py
@@ -3153,6 +3153,14 @@ class Renderer:
         group = max(1, int(args.flat_group_size))
         num_sw = Renderer.validate_flat_topology(total, group)
 
+        # CML input validation requires x/y coordinates to be within a bounded range.
+        # Scale spacing so any node count and group size produces importable coordinates.
+        max_coord = 15000
+        base_distance = int(getattr(args, "distance", 200))
+        base_sw_step_x = base_distance * 3
+        sw_step_x = max(1, min(base_sw_step_x, max_coord // max(1, (num_sw + 1))))
+        router_step_y = max(1, min(base_distance, max_coord // max(1, (group + 2))))
+
         # Warn about custom device templates/images which may affect interface behavior
         dev_def = getattr(args, "dev_template", args.template)
         if dev_def != "iosv":
@@ -3260,7 +3268,7 @@ class Renderer:
         for i in range(num_sw):
             label = f"SW{i+1}"
             node_ids[label] = f"n{nid}"; nid += 1
-            x = (i + 1) * args.distance * 3
+            x = min(max_coord, (i + 1) * sw_step_x)
             lines.append(f"  - id: {node_ids[label]}")
             lines.append(f"    label: {label}")
             lines.append("    node_definition: unmanaged_switch")
@@ -3415,8 +3423,8 @@ class Renderer:
                     rendered, label, cfg.domainname, ca_url
                 )
 
-            rx = (idx // group + 1) * args.distance * 3
-            ry = (idx % group + 1) * args.distance
+            rx = min(max_coord, (idx // group + 1) * sw_step_x)
+            ry = min(max_coord, (idx % group + 1) * router_step_y)
             lines.append(f"  - id: {node_ids[label]}")
             lines.append(f"    label: {label}")
             lines.append(f"    node_definition: {dev_def}")
@@ -3711,6 +3719,14 @@ class Renderer:
         group = max(1, int(args.flat_group_size))
         num_sw = Renderer.validate_flat_topology(total, group)
 
+        # CML input validation requires x/y coordinates to be within a bounded range.
+        # Scale spacing so any node count and group size produces importable coordinates.
+        max_coord = 15000
+        base_distance = int(getattr(args, "distance", 200))
+        base_sw_step_x = base_distance * 3
+        sw_step_x = max(1, min(base_sw_step_x, max_coord // max(1, (num_sw + 1))))
+        router_step_y = max(1, min(base_distance, max_coord // max(1, (group + 2))))
+
         # helper to compute addressing
         def addr_parts(n: int) -> tuple[int, int]:
             ridx = n
@@ -3799,7 +3815,7 @@ class Renderer:
         for i in range(num_sw):
             label = f"SW{i+1}"
             node_ids[label] = f"n{nid}"; nid += 1
-            x = (i + 1) * args.distance * 3
+            x = min(max_coord, (i + 1) * sw_step_x)
             lines.append(f"  - id: {node_ids[label]}")
             lines.append(f"    label: {label}")
             lines.append("    node_definition: unmanaged_switch")
@@ -3991,8 +4007,8 @@ class Renderer:
                     rendered, label, cfg.domainname, ca_url
                 )
 
-            rx = (idx // group + 1) * args.distance * 3
-            ry = (idx % group + 1) * args.distance
+            rx = min(max_coord, (idx // group + 1) * sw_step_x)
+            ry = min(max_coord, (idx % group + 1) * router_step_y)
             lines.append(f"  - id: {node_ids[label]}")
             lines.append(f"    label: {label}")
             lines.append(f"    node_definition: {dev_def}")


### PR DESCRIPTION
…at_pair_yaml

CML rejects lab import when any node x/y exceeds 15000. offline_flat_yaml and offline_flat_pair_yaml computed switch x as (i+1)*distance*3 with no upper bound; at 26 access switches (520 nodes, group=20) the last switch landed at x=15600 and import failed. offline_dmvpn_yaml already had the correct scaling logic. Apply the same sw_step_x/router_step_y scaling to both flat renderers so coordinates always fit within max_coord=15000 regardless of node count or --flat-group-size.

src/topogen/render.py: v1.0.13 → v1.0.14
CHANGES.md: v1.2.8 → v1.2.9
README.md: v1.4.8 → v1.4.9
TODO.md: v1.6.12 (bug marked resolved)