### PR TITLE
fix(templates): CSR/IOSv day-0 Gi numbering for nx high-degree nodes (TG-169)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.3.9
+Doc Version: v1.3.10
 Date Modified: 2026-06-08
 
 - Called by: Users checking release notes, package managers, documentation generators
@@ -20,6 +20,9 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - fix(nac): `--nac --mgmt` mgmt-bridge DHCP OOB deployable via Terraform (TG-146)
+    - Exclude OOB Gi5 from Terraform-managed `ethernets`; `host` is connection target only (no fake `10.254.0.x` static). CSR/IOSv templates skip mgmt slot in data-plane loops and use `slot + 1` for day-0 Gi numbering. Added `scripts/sync-nac-mgmt-dhcp.py`, `scripts/nac-minimal-from-live.py`, and regression tests. Live-validated on CML 2.10: N45 full apply/destroy (Gi5 DHCP preserved), N48 48-node DHCP sync + NETCONF via real mgmt IPs.
+    - Files: src/topogen/nac.py, src/topogen/render.py, src/topogen/templates/csr-*.jinja2, src/topogen/templates/iosv*.jinja2, scripts/sync-nac-mgmt-dhcp.py (rev v1.0.0), scripts/nac-minimal-from-live.py (rev v1.0.0), tests/test_nac_writer.py, CHANGES.md (rev v1.3.9 → v1.3.10)
   - docs(version): sync package v0.3.0 in README provenance example and DEVELOPER version guidance (TG-168)
     - README intent-metadata example updated from `v0.2.5` to `v0.3.0`; DEVELOPER clarifies package version vs `--cml-version`; TODO bump task note updated for TG-147 release.
     - Files: README.md (rev v1.8.5 → v1.8.6), DEVELOPER.md (rev v1.8.7 → v1.8.8), TODO.md (rev v1.6.48 → v1.6.49), CHANGES.md (rev v1.3.8 → v1.3.9)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.3.10
+Doc Version: v1.3.11
 Date Modified: 2026-06-08
 
 - Called by: Users checking release notes, package managers, documentation generators
@@ -20,6 +20,9 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - fix(templates): CSR/IOSv day-0 Gi numbering uses topo `iface.slot` on nx high-degree nodes (TG-169)
+    - CSR data-plane stanzas and EEM noshut loops emit `GigabitEthernet{{ iface.slot + 1 }}` instead of `loop.index0 + 1`, so reserved OOB Gi5 is not reused for mesh links after slot skip. IOSv templates use `GigabitEthernet0/{{ iface.slot }}`. Fixes CDP-up/OSPF-down and Terraform Gi7 overlap on busy routers; NaC model unchanged.
+    - Files: src/topogen/templates/csr-ospf.jinja2 (rev v1.3.0 → v1.3.1), csr-eigrp.jinja2 (v1.3.0 → v1.3.1), csr1000v.jinja2 (v1.0.0 → v1.0.1), csr-getvpn-ks.jinja2 (v1.0.1 → v1.0.2), csr-pki-ca.jinja2 (v1.3.4 → v1.3.5), iosv.jinja2 (v1.1.3 → v1.1.4), iosv-eigrp.jinja2 (v1.1.1 → v1.1.2), iosv-eigrp-nonflat.jinja2 (v1.1.3 → v1.1.4), iosv-eigrp-stub.jinja2 (v1.1.3 → v1.1.4), tests/test_nac_writer.py (v1.15.0 → v1.16.0), CHANGES.md (v1.3.10 → v1.3.11)
   - fix(nac): `--nac --mgmt` mgmt-bridge DHCP OOB deployable via Terraform (TG-146)
     - Exclude OOB Gi5 from Terraform-managed `ethernets`; `host` is connection target only (no fake `10.254.0.x` static). CSR/IOSv templates skip mgmt slot in data-plane loops and use `slot + 1` for day-0 Gi numbering. Added `scripts/sync-nac-mgmt-dhcp.py`, `scripts/nac-minimal-from-live.py`, and regression tests. Live-validated on CML 2.10: N45 full apply/destroy (Gi5 DHCP preserved), N48 48-node DHCP sync + NETCONF via real mgmt IPs.
     - Files: src/topogen/nac.py, src/topogen/render.py, src/topogen/templates/csr-*.jinja2, src/topogen/templates/iosv*.jinja2, scripts/sync-nac-mgmt-dhcp.py (rev v1.0.0), scripts/nac-minimal-from-live.py (rev v1.0.0), tests/test_nac_writer.py, CHANGES.md (rev v1.3.9 → v1.3.10)

--- a/scripts/nac-minimal-from-live.py
+++ b/scripts/nac-minimal-from-live.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Strip Terraform-managed data-plane ethernets; keep host, hostname, loopback only."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("nac_yaml", type=Path)
+    args = parser.parse_args()
+    data = yaml.safe_load(args.nac_yaml.read_text(encoding="utf-8")) or {}
+    for device in data.get("iosxe", {}).get("devices", []):
+        config = device.get("configuration", {})
+        ifaces = config.get("interfaces", {})
+        ifaces.pop("ethernets", None)
+        config["interfaces"] = ifaces
+    args.nac_yaml.write_text(
+        yaml.safe_dump(data, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+    print(f"stripped ethernets from {args.nac_yaml}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync-nac-mgmt-dhcp.py
+++ b/scripts/sync-nac-mgmt-dhcp.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Sync NaC mgmt hosts from live CML bridge DHCP addresses on GigabitEthernet5/0/5."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from ipaddress import ip_address
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+MGMT_IFACE_FILTER = "GigabitEthernet5"
+BRIDGE_PREFIX = "192.168.1."
+DHCP_FIX_COMMANDS = (
+    "interface GigabitEthernet5\n"
+    "no ip address\n"
+    "ip address dhcp\n"
+    "no shutdown"
+)
+IP_RE = re.compile(r"\b(\d{1,3}(?:\.\d{1,3}){3})\b")
+
+
+def _canonical_name(index: int) -> str:
+    return f"iosv-{index:02d}"
+
+
+def _parse_mgmt_ip(output: str) -> str | None:
+    for line in output.splitlines():
+        if MGMT_IFACE_FILTER not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        candidate = parts[1]
+        if candidate == "unassigned":
+            continue
+        try:
+            ip = ip_address(candidate)
+        except ValueError:
+            continue
+        if str(ip).startswith(BRIDGE_PREFIX):
+            return str(ip)
+    return None
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _dump_yaml(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _patch_nac_files(nac_root: Path, mapping: dict[str, str]) -> None:
+    nac_yaml = nac_root / "nac.yaml"
+    inventory_yaml = nac_root / "inventory.yaml"
+    devices_yaml = nac_root / "devices.yaml"
+
+    nac_data = _load_yaml(nac_yaml)
+    for device in nac_data.get("iosxe", {}).get("devices", []):
+        name = device.get("name", "")
+        if name in mapping:
+            device["host"] = mapping[name]
+    _dump_yaml(nac_yaml, nac_data)
+
+    inv_data = _load_yaml(inventory_yaml)
+    host_groups: list[dict] = []
+    all_block = inv_data.get("all", {})
+    if isinstance(all_block.get("hosts"), dict):
+        host_groups.append(all_block["hosts"])
+    for group in all_block.get("children", {}).values():
+        if isinstance(group, dict) and isinstance(group.get("hosts"), dict):
+            host_groups.append(group["hosts"])
+    for hosts in host_groups:
+        for host_name, host_vars in hosts.items():
+            if host_name in mapping and isinstance(host_vars, dict):
+                host_vars["ansible_host"] = mapping[host_name]
+    _dump_yaml(inventory_yaml, inv_data)
+
+    dev_data = _load_yaml(devices_yaml)
+    for device in dev_data.get("devices", []):
+        name = device.get("name", "")
+        if name in mapping:
+            device["mgmt_ip"] = mapping[name]
+    _dump_yaml(devices_yaml, dev_data)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lab-id", help="CML lab UUID (required unless --mapping-file)")
+    parser.add_argument("--nac-root", required=True, type=Path, help="Path to nac/ output tree")
+    parser.add_argument(
+        "--mapping-file",
+        type=Path,
+        help="JSON map of iosv-NN -> 192.168.1.x (skip CML polling)",
+    )
+    parser.add_argument(
+        "--fix-dhcp",
+        action="store_true",
+        help="Push Gi5 DHCP remediation on BOOTED routers before reading addresses",
+    )
+    parser.add_argument(
+        "--mgmt-slot",
+        type=int,
+        default=5,
+        help="CSR mgmt interface slot (default 5 -> GigabitEthernet5)",
+    )
+    args = parser.parse_args()
+
+    global MGMT_IFACE_FILTER
+    MGMT_IFACE_FILTER = f"GigabitEthernet{args.mgmt_slot}"
+
+    if args.mapping_file:
+        mapping = json.loads(args.mapping_file.read_text(encoding="utf-8"))
+        _patch_nac_files(args.nac_root, mapping)
+        report_path = args.nac_root / "mgmt_dhcp_sync.json"
+        report_path.write_text(
+            json.dumps({"synced": len(mapping), "mapping": mapping}, indent=2),
+            encoding="utf-8",
+        )
+        print(json.dumps({"synced": len(mapping), "report": str(report_path)}, indent=2))
+        return 0
+
+    if not args.lab_id:
+        print("--lab-id is required unless --mapping-file is provided", file=sys.stderr)
+        return 1
+
+    try:
+        from virl2_client import ClientLibrary
+    except ImportError:
+        print("virl2_client is required", file=sys.stderr)
+        return 1
+
+    url = os.environ.get("VIRL2_URL", "https://192.168.1.183")
+    user = os.environ.get("VIRL2_USER", "")
+    password = os.environ.get("VIRL2_PASS", "")
+    client = ClientLibrary(url, user, password, ssl_verify=False)
+    lab = client.join_existing_lab(args.lab_id)
+
+    mapping: dict[str, str] = {}
+    report: dict[str, object] = {
+        "lab_id": args.lab_id,
+        "nac_root": str(args.nac_root),
+        "mgmt_interface": MGMT_IFACE_FILTER,
+        "routers": {},
+    }
+
+    for node in lab.nodes():
+        if node.node_definition != "csr1000v":
+            continue
+        label = node.label
+        if not label.startswith("R") or not label[1:].isdigit():
+            continue
+        index = int(label[1:])
+        canonical = _canonical_name(index)
+        entry: dict[str, str | None] = {"state": str(node.state), "mgmt_ip": None, "error": None}
+
+        if str(node.state) != "BOOTED":
+            report["routers"][label] = entry
+            continue
+
+        try:
+            if args.fix_dhcp:
+                node.run_pyats_config_command(
+                    DHCP_FIX_COMMANDS.replace("GigabitEthernet5", MGMT_IFACE_FILTER)
+                )
+            show_cmd = f"show ip interface brief | include {MGMT_IFACE_FILTER}"
+            output = node.run_pyats_command(show_cmd, config=False)
+            mgmt_ip = _parse_mgmt_ip(str(output))
+            entry["mgmt_ip"] = mgmt_ip
+            if mgmt_ip:
+                mapping[canonical] = mgmt_ip
+        except Exception as exc:  # noqa: BLE001 - surface per-node CML/pyATS failures
+            entry["error"] = str(exc)
+
+        report["routers"][label] = entry
+
+    if mapping:
+        _patch_nac_files(args.nac_root, mapping)
+
+    report["synced"] = len(mapping)
+    report_path = args.nac_root / "mgmt_dhcp_sync.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({"synced": len(mapping), "report": str(report_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/topogen/nac.py
+++ b/src/topogen/nac.py
@@ -173,7 +173,11 @@ def _select_host(node: TopogenNode, args) -> str:
         for iface in node_interfaces:
             description = str(_get_iface_value(iface, "description", ""))
             if description == "OOB Management":
-                return _normalize_ipv4_host(_get_iface_value(iface, "address", None))
+                address = _get_iface_value(iface, "address", None)
+                if address:
+                    return _normalize_ipv4_host(address)
+                if bool(getattr(args, "mgmt_bridge", False)):
+                    return ""
         return ""
 
     data_interfaces = sorted(

--- a/src/topogen/render.py
+++ b/src/topogen/render.py
@@ -692,11 +692,15 @@ def _append_nac_mgmt_interface(node: TopogenNode, args: Namespace, router_index:
     mgmt_slot = int(getattr(args, "mgmt_slot", 5))
     dev_def = str(getattr(args, "dev_template", getattr(args, "template", ""))).lower()
     model_slot = mgmt_slot - 1 if dev_def == "csr1000v" else mgmt_slot
+    mgmt_bridge = bool(getattr(args, "mgmt_bridge", False))
+    mgmt_address = None
+    if not mgmt_bridge:
+        mgmt_address = IPv4Interface(
+            f"{mgmt_net.network_address + router_index}/{mgmt_net.prefixlen}"
+        )
     node.interfaces.append(
         TopogenInterface(
-            address=IPv4Interface(
-                f"{mgmt_net.network_address + router_index}/{mgmt_net.prefixlen}"
-            ),
+            address=mgmt_address,
             vrf=getattr(args, "mgmt_vrf", None),
             description="OOB Management",
             slot=model_slot,

--- a/src/topogen/templates/csr-eigrp.jinja2
+++ b/src/topogen/templates/csr-eigrp.jinja2
@@ -26,7 +26,7 @@ username {{ config.username }} privilege 15 secret {{ config.password }}
 cdp run
 !
 {%- set ns = namespace(seen={}) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 {%- if iface.vrf and not ns.seen.get(iface.vrf) %}
 vrf definition {{ iface.vrf }}
  rd 1:1
@@ -71,7 +71,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -83,13 +83,13 @@ router eigrp 100
  eigrp stub connected summary
  {%- endif %}
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
@@ -167,7 +167,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr-eigrp.jinja2
+++ b/src/topogen/templates/csr-eigrp.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.3.0
-# Date Modified: 2026-02-25
+# Doc Version: v1.3.1
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp)
@@ -90,7 +90,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}
@@ -168,7 +168,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-getvpn-ks.jinja2
+++ b/src/topogen/templates/csr-getvpn-ks.jinja2
@@ -7,8 +7,8 @@
 #            This template uses CSR-style interface names (GigabitEthernet1, not Gi0/1).
 #
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.0.1
-# Date Modified: 2026-03-20
+# Doc Version: v1.0.2
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (offline renderers)
 # - Reads from: Jinja context (config, node, getvpn_*, mgmt, ntp, archive)
@@ -187,7 +187,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}
@@ -270,7 +270,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-getvpn-ks.jinja2
+++ b/src/topogen/templates/csr-getvpn-ks.jinja2
@@ -171,7 +171,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -180,13 +180,13 @@ router eigrp TOPGEN
 {%- else %}
 router eigrp 100
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
@@ -269,7 +269,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr-ospf.jinja2
+++ b/src/topogen/templates/csr-ospf.jinja2
@@ -68,11 +68,11 @@ int Loopback0
 router ospf 1
     passive-interface Loopback0
     network {{ node.loopback.ip }} 0.0.0.0 area 0
-{%- for iface in node.interfaces if iface.address %}
+{%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
     network {{ iface.address.ip }} 0.0.0.0 area 0
 {%- endfor %}
 !
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
@@ -150,7 +150,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr-ospf.jinja2
+++ b/src/topogen/templates/csr-ospf.jinja2
@@ -4,8 +4,8 @@
 #          Used for both regular routers and PKI CA when --pki flag is enabled.
 #
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.3.0
-# Date Modified: 2026-02-25
+# Doc Version: v1.3.1
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step in offline_flat_yaml)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp)
@@ -73,7 +73,7 @@ router ospf 1
 {%- endfor %}
 !
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}
@@ -151,7 +151,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-pki-ca.jinja2
+++ b/src/topogen/templates/csr-pki-ca.jinja2
@@ -8,8 +8,8 @@
 #            Future TODO: Support IOSv if PKI server works on IOSv platform.
 #
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.3.4
-# Date Modified: 2026-03-24
+# Doc Version: v1.3.5
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step in offline_flat_yaml)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, pki_enabled)
@@ -121,7 +121,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if loop.first %}
     description === SCEP Enrollment URL ===
     {%- elif iface.description %}
@@ -233,7 +233,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-pki-ca.jinja2
+++ b/src/topogen/templates/csr-pki-ca.jinja2
@@ -102,7 +102,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -114,13 +114,13 @@ router eigrp 100
  eigrp stub connected summary
  {%- endif %}
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if loop.first %}
     description === SCEP Enrollment URL ===
@@ -232,7 +232,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr1000v.jinja2
+++ b/src/topogen/templates/csr1000v.jinja2
@@ -64,7 +64,7 @@ router ospf 2 vrf {{ iface.vrf }}
 !
 {%- endif %}
 {%- endfor %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/csr1000v.jinja2
+++ b/src/topogen/templates/csr1000v.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.0.0
-# Date Modified: 2026-06-03
+# Doc Version: v1.0.1
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: origin, mgmt, ntp, ntp_oob, archive)
@@ -65,7 +65,7 @@ router ospf 2 vrf {{ iface.vrf }}
 {%- endif %}
 {%- endfor %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv-eigrp-nonflat.jinja2
+++ b/src/topogen/templates/iosv-eigrp-nonflat.jinja2
@@ -38,7 +38,7 @@ router eigrp 100
     network 172.16.0.0 0.15.255.255
     no auto-summary
 !
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/iosv-eigrp-nonflat.jinja2
+++ b/src/topogen/templates/iosv-eigrp-nonflat.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.3
-# Date Modified: 2026-03-23
+# Doc Version: v1.1.4
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, ntp_oob, archive)
@@ -39,7 +39,7 @@ router eigrp 100
     no auto-summary
 !
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv-eigrp-stub.jinja2
+++ b/src/topogen/templates/iosv-eigrp-stub.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.3
-# Date Modified: 2026-03-23
+# Doc Version: v1.1.4
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, ntp_oob, eigrp_stub, archive)
@@ -84,7 +84,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv-eigrp-stub.jinja2
+++ b/src/topogen/templates/iosv-eigrp-stub.jinja2
@@ -68,7 +68,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -77,13 +77,13 @@ router eigrp TOPGEN
 {%- else %}
 router eigrp 100
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/iosv-eigrp.jinja2
+++ b/src/topogen/templates/iosv-eigrp.jinja2
@@ -68,7 +68,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -80,13 +80,13 @@ router eigrp 100
  eigrp stub connected summary
  {%- endif %}
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/iosv-eigrp.jinja2
+++ b/src/topogen/templates/iosv-eigrp.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.1
-# Date Modified: 2026-02-16
+# Doc Version: v1.1.2
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, eigrp_stub)
@@ -87,7 +87,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv.jinja2
+++ b/src/topogen/templates/iosv.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.3
-# Date Modified: 2026-03-23
+# Doc Version: v1.1.4
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: origin, mgmt, ntp, ntp_oob, archive)
@@ -63,7 +63,7 @@ router ospf 2 vrf {{ iface.vrf }}
 {%- endif %}
 {%- endfor %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv.jinja2
+++ b/src/topogen/templates/iosv.jinja2
@@ -62,7 +62,7 @@ router ospf 2 vrf {{ iface.vrf }}
 !
 {%- endif %}
 {%- endfor %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/tests/test_nac_writer.py
+++ b/tests/test_nac_writer.py
@@ -1,6 +1,6 @@
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.15.0
-# Date Modified: 2026-06-04
+# Doc Version: v1.16.0
+# Date Modified: 2026-06-08
 #
 # - Called by: Developers/CI via unittest discovery
 # - Reads from: src/topogen/main.py, src/topogen/nac.py
@@ -10,15 +10,18 @@
 # Purpose: Verify canonical NaC writer output layout, keys, deterministic rerun behavior, and DMVPN artifact paths.
 # Blast Radius: Test-only; no runtime behavior changes.
 
+import re
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from ipaddress import IPv4Interface
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import yaml
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +29,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from topogen.config import Config  # pylint: disable=wrong-import-position
 from topogen.main import main  # pylint: disable=wrong-import-position
 from topogen.models import TopogenInterface, TopogenNode  # pylint: disable=wrong-import-position
 from topogen.nac import (  # pylint: disable=wrong-import-position
@@ -40,6 +44,23 @@ from topogen.nac import (  # pylint: disable=wrong-import-position
     write_terraform_scaffold,
     write_verify_reachability_yaml,
 )
+
+
+def _extract_day0_config(node: dict) -> str:
+    cfg = node.get("configuration", "")
+    if isinstance(cfg, list):
+        return cfg[0].get("content", "") if cfg else ""
+    return cfg
+
+
+def _interface_names(config: str) -> list[str]:
+    return re.findall(r"^interface (GigabitEthernet\S+)$", config, re.MULTILINE)
+
+
+def _interface_stanza(config: str, iface_name: str) -> str:
+    pattern = rf"^interface {re.escape(iface_name)}$(.*?)(?=^interface |\nend\n|\Z)"
+    match = re.search(pattern, config, re.MULTILINE | re.DOTALL)
+    return match.group(0) if match else ""
 
 
 class TestNacWriter(unittest.TestCase):
@@ -1017,6 +1038,128 @@ class TestNacWriter(unittest.TestCase):
             ],
         )
         self.assertFalse(any(iface.get("description") == "OOB Management" for iface in ethernets))
+
+    def _high_degree_csr_node(self) -> TopogenNode:
+        return TopogenNode(
+            hostname="R5",
+            loopback=IPv4Interface("10.0.0.5/32"),
+            interfaces=[
+                TopogenInterface(address=IPv4Interface("172.16.0.14/30"), slot=0, description="to R1"),
+                TopogenInterface(
+                    address=None,
+                    vrf="Mgmt-vrf",
+                    description="OOB Management",
+                    slot=4,
+                ),
+                TopogenInterface(address=IPv4Interface("172.16.0.73/30"), slot=5, description="to R12"),
+                TopogenInterface(address=IPv4Interface("172.16.0.65/30"), slot=6, description="to R16"),
+            ],
+        )
+
+    def test_csr_day0_uses_topo_slot_not_loop_index(self):
+        """TG-169: CSR data-plane Gi numbers must follow iface.slot + 1 after mgmt skip."""
+        env = Environment(loader=PackageLoader("topogen"), autoescape=select_autoescape())
+        tpl = env.get_template("csr-ospf.jinja2")
+        node = self._high_degree_csr_node()
+        rendered = tpl.render(
+            config=Config(),
+            node=node,
+            date=datetime.now(timezone.utc),
+            mgmt={"enabled": True, "slot": 5, "vrf": "Mgmt-vrf", "gw": None},
+        )
+        names = _interface_names(rendered)
+        self.assertEqual(names.count("GigabitEthernet5"), 1)
+        gi5 = _interface_stanza(rendered, "GigabitEthernet5")
+        self.assertIn("ip address dhcp", gi5)
+        self.assertIn("OOB Management", gi5)
+        gi6 = _interface_stanza(rendered, "GigabitEthernet6")
+        self.assertIn("172.16.0.73", gi6)
+        self.assertIn("to R12", gi6)
+        gi7 = _interface_stanza(rendered, "GigabitEthernet7")
+        self.assertIn("172.16.0.65", gi7)
+        self.assertIn("network 172.16.0.73 0.0.0.0 area 0", rendered)
+        self.assertIn("network 172.16.0.65 0.0.0.0 area 0", rendered)
+        self.assertNotRegex(rendered, r"interface GigabitEthernet5\n.*ip address 172\.16")
+
+    def test_iosv_day0_uses_topo_slot_not_loop_index(self):
+        """TG-169: IOSv data-plane Gi numbers must follow iface.slot after mgmt skip."""
+        env = Environment(loader=PackageLoader("topogen"), autoescape=select_autoescape())
+        tpl = env.get_template("iosv.jinja2")
+        node = TopogenNode(
+            hostname="R5",
+            loopback=IPv4Interface("10.0.0.5/32"),
+            interfaces=[
+                TopogenInterface(address=IPv4Interface("172.16.0.14/30"), slot=0, description="to R1"),
+                TopogenInterface(
+                    address=None,
+                    vrf="Mgmt-vrf",
+                    description="OOB Management",
+                    slot=5,
+                ),
+                TopogenInterface(address=IPv4Interface("172.16.0.73/30"), slot=6, description="to R12"),
+            ],
+        )
+        rendered = tpl.render(
+            config=Config(),
+            node=node,
+            date=datetime.now(timezone.utc),
+            mgmt={"enabled": True, "slot": 5, "vrf": "Mgmt-vrf", "gw": None},
+        )
+        names = _interface_names(rendered)
+        self.assertEqual(names.count("GigabitEthernet0/5"), 1)
+        gi5 = _interface_stanza(rendered, "GigabitEthernet0/5")
+        self.assertIn("ip address dhcp", gi5)
+        gi6 = _interface_stanza(rendered, "GigabitEthernet0/6")
+        self.assertIn("172.16.0.73", gi6)
+        self.assertNotRegex(rendered, r"interface GigabitEthernet0/5\n.*ip address 172\.16")
+
+    def test_nx_mgmt_bridge_offline_yaml_no_duplicate_csr_gi5(self):
+        """TG-169: nx + mgmt-bridge CSR day-0 must not double-book Gi5 on high-degree nodes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out_file = Path(tmp) / "out" / "nx-mgmt-bridge-csr.yaml"
+            rc = self._run_main(
+                [
+                    "10",
+                    "--mode",
+                    "nx",
+                    "-T",
+                    "csr-ospf",
+                    "--device-template",
+                    "csr1000v",
+                    "--offline-yaml",
+                    str(out_file),
+                    "--mgmt",
+                    "--mgmt-bridge",
+                    "--mgmt-slot",
+                    "5",
+                    "--overwrite",
+                ]
+            )
+            self.assertEqual(rc, 0)
+            lab = yaml.safe_load(out_file.read_text(encoding="utf-8"))
+            routers = [
+                node
+                for node in lab["nodes"]
+                if node.get("node_definition") == "csr1000v"
+                and node.get("label", "").startswith("R")
+            ]
+            self.assertGreaterEqual(len(routers), 10)
+            for router in routers:
+                config = _extract_day0_config(router)
+                names = _interface_names(config)
+                self.assertEqual(len(names), len(set(names)), router["label"])
+                self.assertLessEqual(names.count("GigabitEthernet5"), 1, router["label"])
+                if "GigabitEthernet5" in names:
+                    gi5 = _interface_stanza(config, "GigabitEthernet5")
+                    self.assertIn("ip address dhcp", gi5, router["label"])
+                    self.assertNotRegex(
+                        config,
+                        r"interface GigabitEthernet5\n.*ip address 172\.16",
+                        router["label"],
+                    )
+                busy = [name for name in names if name not in {"GigabitEthernet5", "Loopback0"}]
+                if len(busy) >= 5:
+                    self.assertIn("GigabitEthernet6", names, router["label"])
 
     def test_flat_pair_cli_vrf_reaches_nac_output(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_nac_writer.py
+++ b/tests/test_nac_writer.py
@@ -983,6 +983,41 @@ class TestNacWriter(unittest.TestCase):
         self.assertNotIn("vrfs", config)
         self.assertNotIn("vrf_forwarding", config["interfaces"]["ethernets"][0])
 
+    def test_csr_mgmt_emits_post_oob_data_interfaces(self):
+        """CSR Gi6+ data links must be Terraform-managed; only OOB Gi5 is excluded."""
+        node = TopogenNode(
+            hostname="R5",
+            loopback=IPv4Interface("10.0.0.5/32"),
+            interfaces=[
+                TopogenInterface(address=IPv4Interface("172.16.0.14/30"), slot=0, description="to R1"),
+                TopogenInterface(
+                    address=None,
+                    vrf="Mgmt-vrf",
+                    description="OOB Management",
+                    slot=4,
+                ),
+                TopogenInterface(address=IPv4Interface("172.16.0.73/30"), slot=5, description="to R12"),
+                TopogenInterface(address=IPv4Interface("172.16.0.65/30"), slot=6, description="to R16"),
+            ],
+        )
+        model = build_canonical_nac_model(
+            node,
+            device_template="csr1000v",
+            template="csr-eigrp",
+            mode="nx",
+            args=SimpleNamespace(enable_mgmt=True, mgmt_slot=5, mgmt_bridge=True),
+        )
+        ethernets = model["iosxe"]["devices"][0]["configuration"]["interfaces"]["ethernets"]
+        self.assertEqual(
+            [(iface["id"], iface.get("description")) for iface in ethernets],
+            [
+                ("1", "to R1"),
+                ("6", "to R12"),
+                ("7", "to R16"),
+            ],
+        )
+        self.assertFalse(any(iface.get("description") == "OOB Management" for iface in ethernets))
+
     def test_flat_pair_cli_vrf_reaches_nac_output(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_file = Path(tmp) / "out" / "flat-pair-vrf.yaml"


### PR DESCRIPTION
## Summary
- CSR data-plane and EEM noshut loops use `iface.slot + 1` instead of `loop.index0 + 1`, so reserved OOB Gi5 is not reused for mesh links after TG-167 slot skip.
- IOSv templates use `GigabitEthernet0/{{ iface.slot }}` for the same reason.
- Adds regression tests (template unit + 10-node nx offline e2e) and CHANGES.md Unreleased entry.

## Root cause
After TG-146/TG-167 excluded OOB from data-plane loops and skipped mgmt slot in topology, Jinja templates still numbered interfaces by loop index. High-degree routers got a data link on Gi5 colliding with OOB DHCP → CDP up on Gi6+ but OSPF 0/0; NaC/terraform Gi7 overlap at scale.

## Test plan
- [x] `python -m pytest tests/test_nac_writer.py -q` — 45 passed
- [x] Live CML TG-169-smoke (10-node nx, csr-ospf, mgmt-bridge): R9 (degree 8) Gi5 DHCP only; Gi6/Gi7 data; OSPF FULL on Gi1-4, Gi6, Gi7

## Live evidence (R9)
- `show ip int brief`: Gi5 = 192.168.1.147 DHCP; Gi6-8 = 172.16.x data
- `show ip ospf neighbor`: FULL on Gi1-4, Gi6, Gi7

Merge preference: squash (per DEVELOPER.md closeout checklist).

Note: `cisco` remote push failed (wwwin-github.cisco.com unreachable from this environment); branch pushed to `origin`.

Made with [Cursor](https://cursor.com)