### PR TITLE
feat(ci): add terraform plan contract test for NaC output (TG-161)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,9 +11,31 @@
 
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
+  changes:
+    name: "Detect NaC-related changes"
+    if: startsWith(github.ref, 'refs/heads/') || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      nac: ${{ steps.filter.outputs.nac }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            nac:
+              - 'src/topogen/nac.py'
+              - 'src/topogen/render.py'
+              - 'src/topogen/main.py'
+              - 'src/topogen/templates/**'
+              - 'tests/test_nac_*.py'
+              - 'tests/conftest.py'
+              - 'tests/fixtures/nac/**'
+              - '.github/workflows/python-package.yml'
+
   build:
     name: "Build package"
     if: startsWith(github.ref, 'refs/heads/')
@@ -62,3 +84,44 @@ jobs:
       #   with:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
       #     path-to-lcov: coverage.lcov
+
+  nac-terraform-plan:
+    name: "NaC Terraform plan contract"
+    needs: changes
+    if: needs.changes.outputs.nac == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.8.0"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "0.7.9"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache Terraform provider/module downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: nac-tf-plugins-${{ runner.os }}-${{ hashFiles('src/topogen/nac.py') }}
+          restore-keys: |
+            nac-tf-plugins-${{ runner.os }}-
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run NaC terraform plan matrix (TG-161)
+        env:
+          TOPOGEN_TERRAFORM_PLAN: "1"
+          TF_PLUGIN_CACHE_DIR: ${{ runner.temp }}/terraform-plugin-cache
+        run: |
+          mkdir -p "$TF_PLUGIN_CACHE_DIR"
+          uv run pytest tests/test_nac_terraform_plan.py -m terraform -v

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.3.11
+Doc Version: v1.3.12
 Date Modified: 2026-06-08
 
 - Called by: Users checking release notes, package managers, documentation generators
@@ -20,6 +20,9 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - feat(ci): add terraform plan contract test for NaC output (TG-161)
+    - Opt-in pytest matrix (`tests/test_nac_terraform_plan.py`, `-m terraform` / `TOPOGEN_TERRAFORM_PLAN=1`) generates eight offline labs (flat, flat-pair, DMVPN flat/flat-pair × IOSv/CSR) and runs `terraform init` + `terraform plan -input=false` with dummy IOSXE env vars. CI job `NaC Terraform plan contract` runs on NaC-related path changes with warmed `TF_PLUGIN_CACHE_DIR`. Documents short-path Windows workaround in DEVELOPER.md.
+    - Files: tests/test_nac_terraform_plan.py (rev v1.0.0), tests/conftest.py (rev v1.0.0), .github/workflows/python-package.yml, pyproject.toml (rev v1.0.3 → v1.0.4), DEVELOPER.md (rev v1.8.8 → v1.8.9), TODO.md, CHANGES.md (rev v1.3.11 → v1.3.12)
   - fix(templates): CSR/IOSv day-0 Gi numbering uses topo `iface.slot` on nx high-degree nodes (TG-169)
     - CSR data-plane stanzas and EEM noshut loops emit `GigabitEthernet{{ iface.slot + 1 }}` instead of `loop.index0 + 1`, so reserved OOB Gi5 is not reused for mesh links after slot skip. IOSv templates use `GigabitEthernet0/{{ iface.slot }}`. Fixes CDP-up/OSPF-down and Terraform Gi7 overlap on busy routers; NaC model unchanged.
     - Files: src/topogen/templates/csr-ospf.jinja2 (rev v1.3.0 → v1.3.1), csr-eigrp.jinja2 (v1.3.0 → v1.3.1), csr1000v.jinja2 (v1.0.0 → v1.0.1), csr-getvpn-ks.jinja2 (v1.0.1 → v1.0.2), csr-pki-ca.jinja2 (v1.3.4 → v1.3.5), iosv.jinja2 (v1.1.3 → v1.1.4), iosv-eigrp.jinja2 (v1.1.1 → v1.1.2), iosv-eigrp-nonflat.jinja2 (v1.1.3 → v1.1.4), iosv-eigrp-stub.jinja2 (v1.1.3 → v1.1.4), tests/test_nac_writer.py (v1.15.0 → v1.16.0), CHANGES.md (v1.3.10 → v1.3.11)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.3.9
+Doc Version: v1.3.10
 Date Modified: 2026-06-08
 
 - Called by: Users checking release notes, package managers, documentation generators
@@ -20,6 +20,9 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - fix(nac): `--nac --mgmt` mgmt-bridge DHCP OOB deployable via Terraform (TG-146)
+    - Exclude OOB Gi5 from Terraform-managed `ethernets`; `host` is connection target only (no fake `10.254.0.x` static). CSR/IOSv templates skip mgmt slot in data-plane loops and use `slot + 1` for day-0 Gi numbering. Added `scripts/sync-nac-mgmt-dhcp.py`, `scripts/nac-minimal-from-live.py`, and regression tests. Live-validated on CML 2.10: N45 full apply/destroy (Gi5 DHCP preserved), N48 48-node DHCP sync + NETCONF via real mgmt IPs.
+    - Files: src/topogen/nac.py, src/topogen/render.py, src/topogen/templates/csr-*.jinja2, src/topogen/templates/iosv*.jinja2, scripts/sync-nac-mgmt-dhcp.py (rev v1.0.0), scripts/nac-minimal-from-live.py (rev v1.0.0), tests/test_nac_writer.py, CHANGES.md (rev v1.3.9 → v1.3.10)
   - docs(version): sync package v0.3.0 in README provenance example and DEVELOPER version guidance (TG-168)
     - README intent-metadata example updated from `v0.2.5` to `v0.3.0`; DEVELOPER clarifies package version vs `--cml-version`; TODO bump task note updated for TG-147 release.
     - Files: README.md (rev v1.8.5 → v1.8.6), DEVELOPER.md (rev v1.8.7 → v1.8.8), TODO.md (rev v1.6.48 → v1.6.49), CHANGES.md (rev v1.3.8 → v1.3.9)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.3.10
+Doc Version: v1.3.11
 Date Modified: 2026-06-08
 
 - Called by: Users checking release notes, package managers, documentation generators
@@ -20,6 +20,9 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - fix(templates): CSR/IOSv day-0 Gi numbering uses topo `iface.slot` on nx high-degree nodes (TG-169)
+    - CSR data-plane stanzas and EEM noshut loops emit `GigabitEthernet{{ iface.slot + 1 }}` instead of `loop.index0 + 1`, so reserved OOB Gi5 is not reused for mesh links after slot skip. IOSv templates use `GigabitEthernet0/{{ iface.slot }}`. Fixes CDP-up/OSPF-down and Terraform Gi7 overlap on busy routers; NaC model unchanged.
+    - Files: src/topogen/templates/csr-ospf.jinja2 (rev v1.3.0 → v1.3.1), csr-eigrp.jinja2 (v1.3.0 → v1.3.1), csr1000v.jinja2 (v1.0.0 → v1.0.1), csr-getvpn-ks.jinja2 (v1.0.1 → v1.0.2), csr-pki-ca.jinja2 (v1.3.4 → v1.3.5), iosv.jinja2 (v1.1.3 → v1.1.4), iosv-eigrp.jinja2 (v1.1.1 → v1.1.2), iosv-eigrp-nonflat.jinja2 (v1.1.3 → v1.1.4), iosv-eigrp-stub.jinja2 (v1.1.3 → v1.1.4), tests/test_nac_writer.py (v1.15.0 → v1.16.0), CHANGES.md (v1.3.10 → v1.3.11)
   - fix(nac): `--nac --mgmt` mgmt-bridge DHCP OOB deployable via Terraform (TG-146)
     - Exclude OOB Gi5 from Terraform-managed `ethernets`; `host` is connection target only (no fake `10.254.0.x` static). CSR/IOSv templates skip mgmt slot in data-plane loops and use `slot + 1` for day-0 Gi numbering. Added `scripts/sync-nac-mgmt-dhcp.py`, `scripts/nac-minimal-from-live.py`, and regression tests. Live-validated on CML 2.10: N45 full apply/destroy (Gi5 DHCP preserved), N48 48-node DHCP sync + NETCONF via real mgmt IPs.
     - Files: src/topogen/nac.py, src/topogen/render.py, src/topogen/templates/csr-*.jinja2, src/topogen/templates/iosv*.jinja2, scripts/sync-nac-mgmt-dhcp.py (rev v1.0.0), scripts/nac-minimal-from-live.py (rev v1.0.0), tests/test_nac_writer.py, CHANGES.md (rev v1.3.9 → v1.3.10)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md - this file!):
-Doc Version: v1.8.8
+Doc Version: v1.8.9
 Date Modified: 2026-06-08
 
 - Called by: Developers (new contributors, AI assistants), maintainers
@@ -369,6 +369,46 @@ Tests (run when touching NaC):
 | `tests/test_nac_day0_restconf.py` | RESTCONF/NETCONF lines in day0 when `--nac` |
 | `tests/test_nac_render_e2e.py` | End-to-end offline runs: flat, flat-pair, DMVPN flat/flat-pair; non-NaC paths skip `nac/` |
 | `tests/test_nac_golden_smoke.py` | Regenerates committed golden fixtures under `tests/fixtures/nac/golden-flat-*` |
+| `tests/test_nac_terraform_plan.py` | TG-161: opt-in `terraform init` + `terraform plan` contract against pinned `netascode/nac-iosxe` (8-case matrix) |
+
+### NaC Terraform plan contract gate (TG-161)
+
+Golden fixtures and `terraform validate` do not evaluate module locals from `nac.yaml`.
+Only `terraform plan` catches schema mismatches (e.g. TG-159 DMVPN tunnel `id` vs `name`).
+
+**When to run:** after changing `nac.py`, NaC projection in `render.py`, or pinned module/provider pins.
+
+**Requirements:** Terraform `>= 1.8.0` on `PATH`, network for `terraform init` (registry downloads).
+
+**Opt-in locally** (default `pytest` skips these tests):
+
+```powershell
+# Windows — use a short temp root to avoid MAX_PATH issues during terraform init
+New-Item -ItemType Directory -Force C:\t | Out-Null
+$env:TOPOGEN_TERRAFORM_PLAN = "1"
+$env:TF_PLUGIN_CACHE_DIR = "C:\t\topogen-tf-plugin-cache"
+$env:IOSXE_USERNAME = "lab"
+$env:IOSXE_PASSWORD = "lab"
+$env:IOSXE_URL = "https://127.0.0.1"
+uv run pytest tests/test_nac_terraform_plan.py -m terraform -v
+```
+
+```bash
+# Linux/macOS
+export TOPOGEN_TERRAFORM_PLAN=1
+export TF_PLUGIN_CACHE_DIR="${TMPDIR:-/tmp}/topogen-tf-plugin-cache"
+export IOSXE_USERNAME=lab IOSXE_PASSWORD=lab IOSXE_URL=https://127.0.0.1
+uv run pytest tests/test_nac_terraform_plan.py -m terraform -v
+```
+
+**Matrix (8 cases):** flat, flat-pair, DMVPN flat, DMVPN flat-pair × IOSv and CSR1000v.
+
+**Success criteria per case:** TopoGen exit 0; `terraform init` exit 0; `terraform plan -input=false`
+exit 0; stdout contains `Plan: N to add, 0 to change, 0 to destroy.`; no `Unsupported attribute`
+or `Error:` lines. No `terraform apply`, no live devices.
+
+**CI:** GitHub Actions job `NaC Terraform plan contract` in `.github/workflows/python-package.yml`
+runs when NaC-related paths change. Uses a warmed `TF_PLUGIN_CACHE_DIR`.
 
 If you extend NaC scope:
 

--- a/TODO.md
+++ b/TODO.md
@@ -135,7 +135,8 @@ Recent completions:
 - [x] Coordinate scaling bug fix: `offline_flat_yaml` / `offline_flat_pair_yaml` auto-scale x/y to stay within CML's 15000-coordinate limit (see CHANGES.md)
 - [x] GET VPN (Group Encrypted Transport VPN) support: `--getvpn` flag with `--getvpn-protocol {gdoi,gikev2}`, KS node (csr-getvpn-ks.jinja2), GM config injection on all routers, requires `--pki`. Works with flat, flat-pair, and dmvpn modes. See CHANGES.md.
 - [x] `--blank` flag: topology-only labs with empty configuration on all router nodes; enables CML Bootstrap Lab. Works offline and online for simple, nx, flat, and flat-pair modes. Not supported with DMVPN, `--pki`, `--getvpn`, or config-only flags (`--ntp`, `--archive`, `--eigrp-stub`, `--vrf`, `--pair-vrf`). See CHANGES.md.
-- [x] NaC MVP baseline stories reconciled with git/Jira evidence (TG-116/117/118/119/120/121/122/123/124/127/128/129 marked Done; epic remains In Progress with TG-125/TG-126/TG-130 open).
+- [x] NaC MVP baseline stories reconciled with git/Jira evidence (TG-116/117/118/119/120/121/122/123/124/127/128/129 marked Done).
+- [x] **NaC MVP epic TG-131 closed** — TG-132…TG-146 Done; extended by TG-147 (v0.3.0). Post-epic: TG-161 (terraform plan CI), TG-162 (DMVPN NaC fidelity). TG-169 (Gi numbering) merged separately.
 - [x] **Deployable NaC MVP (TG-131, TG-S1–S13)** — `--nac` now emits a deployable workspace: lean `nac.yaml` for `netascode/nac-iosxe/iosxe` 0.1.0 (provider `CiscoDevNet/iosxe` 0.15.0, Terraform `>= 1.8.0`), pinned Terraform scaffold (`main.tf`/`versions.tf`/`terraform.tfvars.example`/`.gitignore`), read-only Ansible stub, and day0 RESTCONF/NETCONF. Removed `terraform.tfvars.json`. Added golden-fixture smoke tests (`tests/fixtures/nac/golden-flat-*`). See CHANGES.md and README "NaC MVP scope".
 
 ## Future ideas

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.6.49
+Doc Version: v1.6.50
 Date Modified: 2026-06-08
 
 - Called by: Developers planning features, LLMs adding work items, project management
@@ -136,13 +136,13 @@ Recent completions:
 - [x] GET VPN (Group Encrypted Transport VPN) support: `--getvpn` flag with `--getvpn-protocol {gdoi,gikev2}`, KS node (csr-getvpn-ks.jinja2), GM config injection on all routers, requires `--pki`. Works with flat, flat-pair, and dmvpn modes. See CHANGES.md.
 - [x] `--blank` flag: topology-only labs with empty configuration on all router nodes; enables CML Bootstrap Lab. Works offline and online for simple, nx, flat, and flat-pair modes. Not supported with DMVPN, `--pki`, `--getvpn`, or config-only flags (`--ntp`, `--archive`, `--eigrp-stub`, `--vrf`, `--pair-vrf`). See CHANGES.md.
 - [x] NaC MVP baseline stories reconciled with git/Jira evidence (TG-116/117/118/119/120/121/122/123/124/127/128/129 marked Done).
-- [x] **NaC MVP epic TG-131 closed** — TG-132…TG-146 Done; extended by TG-147 (v0.3.0). Post-epic: TG-161 (terraform plan CI), TG-162 (DMVPN NaC fidelity). TG-169 (Gi numbering) merged separately.
+- [x] **NaC MVP epic TG-131 closed** — TG-132…TG-146 Done; extended by TG-147 (v0.3.0). Post-epic: TG-162 (DMVPN NaC fidelity). TG-161 (terraform plan CI) and TG-169 (Gi numbering) done.
 - [x] **Deployable NaC MVP (TG-131, TG-S1–S13)** — `--nac` now emits a deployable workspace: lean `nac.yaml` for `netascode/nac-iosxe/iosxe` 0.1.0 (provider `CiscoDevNet/iosxe` 0.15.0, Terraform `>= 1.8.0`), pinned Terraform scaffold (`main.tf`/`versions.tf`/`terraform.tfvars.example`/`.gitignore`), read-only Ansible stub, and day0 RESTCONF/NETCONF. Removed `terraform.tfvars.json`. Added golden-fixture smoke tests (`tests/fixtures/nac/golden-flat-*`). See CHANGES.md and README "NaC MVP scope".
 
 ## Future ideas
 
 - [ ] **NaC: `--nac` help text omits `nx`** — the `nodes` positional `--help` string lists `nodes=2 simple/flat/flat-pair` but omits `nx`, even though the standalone `--nac` help and `validate_nac_mvp_guardrails()` allow `nodes=2 --mode nx`. One-line fix in `src/topogen/main.py` argparse help; then refresh the README `--help` block. (Follow-up from TG-S13.)
-- [ ] **NaC: Terraform `init`/`validate` deployability gate** — add an opt-in (CI/manual) `terraform init` + `terraform validate` check against a generated `nac/` workspace to prove provider/module resolution and HCL validity end-to-end. Kept out of the committed pytest suite (needs the Terraform binary + network). (Follow-up from TG-S12/S13.)
+- [x] **NaC: Terraform plan deployability gate (TG-161)** — opt-in pytest (`tests/test_nac_terraform_plan.py`, `TOPOGEN_TERRAFORM_PLAN=1` / `-m terraform`) runs `terraform init` + `terraform plan` on an 8-case NaC matrix; CI job `NaC Terraform plan contract` when NaC paths change. Supersedes the earlier `validate`-only idea (plan evaluates `nac.yaml` module locals).
 - [x] ~~**NaC: extend `--nac` to DMVPN**~~ Done for DMVPN flat and flat-pair offline paths in TG-151; deterministic `nac_router_nodes` feed the shared NaC writer.
 
 - [ ] **TG-109: New feature: FlexVPN** — add FlexVPN (IKEv2-native) hub-and-spoke overlay support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.0.3
+# Doc Version: v1.0.4
 # Date Modified: 2026-06-08
 #
 # - Called by: pip/uv installers, build tools (hatchling), package managers (PyPI)
@@ -84,7 +84,17 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-dev = ["mypy>=1.16.0", "ruff>=0.8.3", "types-networkx>=3.5.0.20250531"]
+dev = [
+  "mypy>=1.16.0",
+  "pytest>=8.0.0",
+  "ruff>=0.8.3",
+  "types-networkx>=3.5.0.20250531",
+]
+
+[tool.pytest.ini_options]
+markers = [
+  "terraform: NaC terraform init/plan contract (needs terraform binary + network)",
+]
 
 [[tool.mypy.overrides]]
 module = ["enlighten.*", "virl2_client.*"]

--- a/scripts/nac-minimal-from-live.py
+++ b/scripts/nac-minimal-from-live.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Strip Terraform-managed data-plane ethernets; keep host, hostname, loopback only."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("nac_yaml", type=Path)
+    args = parser.parse_args()
+    data = yaml.safe_load(args.nac_yaml.read_text(encoding="utf-8")) or {}
+    for device in data.get("iosxe", {}).get("devices", []):
+        config = device.get("configuration", {})
+        ifaces = config.get("interfaces", {})
+        ifaces.pop("ethernets", None)
+        config["interfaces"] = ifaces
+    args.nac_yaml.write_text(
+        yaml.safe_dump(data, sort_keys=False, default_flow_style=False),
+        encoding="utf-8",
+    )
+    print(f"stripped ethernets from {args.nac_yaml}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync-nac-mgmt-dhcp.py
+++ b/scripts/sync-nac-mgmt-dhcp.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Sync NaC mgmt hosts from live CML bridge DHCP addresses on GigabitEthernet5/0/5."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from ipaddress import ip_address
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+MGMT_IFACE_FILTER = "GigabitEthernet5"
+BRIDGE_PREFIX = "192.168.1."
+DHCP_FIX_COMMANDS = (
+    "interface GigabitEthernet5\n"
+    "no ip address\n"
+    "ip address dhcp\n"
+    "no shutdown"
+)
+IP_RE = re.compile(r"\b(\d{1,3}(?:\.\d{1,3}){3})\b")
+
+
+def _canonical_name(index: int) -> str:
+    return f"iosv-{index:02d}"
+
+
+def _parse_mgmt_ip(output: str) -> str | None:
+    for line in output.splitlines():
+        if MGMT_IFACE_FILTER not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        candidate = parts[1]
+        if candidate == "unassigned":
+            continue
+        try:
+            ip = ip_address(candidate)
+        except ValueError:
+            continue
+        if str(ip).startswith(BRIDGE_PREFIX):
+            return str(ip)
+    return None
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _dump_yaml(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _patch_nac_files(nac_root: Path, mapping: dict[str, str]) -> None:
+    nac_yaml = nac_root / "nac.yaml"
+    inventory_yaml = nac_root / "inventory.yaml"
+    devices_yaml = nac_root / "devices.yaml"
+
+    nac_data = _load_yaml(nac_yaml)
+    for device in nac_data.get("iosxe", {}).get("devices", []):
+        name = device.get("name", "")
+        if name in mapping:
+            device["host"] = mapping[name]
+    _dump_yaml(nac_yaml, nac_data)
+
+    inv_data = _load_yaml(inventory_yaml)
+    host_groups: list[dict] = []
+    all_block = inv_data.get("all", {})
+    if isinstance(all_block.get("hosts"), dict):
+        host_groups.append(all_block["hosts"])
+    for group in all_block.get("children", {}).values():
+        if isinstance(group, dict) and isinstance(group.get("hosts"), dict):
+            host_groups.append(group["hosts"])
+    for hosts in host_groups:
+        for host_name, host_vars in hosts.items():
+            if host_name in mapping and isinstance(host_vars, dict):
+                host_vars["ansible_host"] = mapping[host_name]
+    _dump_yaml(inventory_yaml, inv_data)
+
+    dev_data = _load_yaml(devices_yaml)
+    for device in dev_data.get("devices", []):
+        name = device.get("name", "")
+        if name in mapping:
+            device["mgmt_ip"] = mapping[name]
+    _dump_yaml(devices_yaml, dev_data)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lab-id", help="CML lab UUID (required unless --mapping-file)")
+    parser.add_argument("--nac-root", required=True, type=Path, help="Path to nac/ output tree")
+    parser.add_argument(
+        "--mapping-file",
+        type=Path,
+        help="JSON map of iosv-NN -> 192.168.1.x (skip CML polling)",
+    )
+    parser.add_argument(
+        "--fix-dhcp",
+        action="store_true",
+        help="Push Gi5 DHCP remediation on BOOTED routers before reading addresses",
+    )
+    parser.add_argument(
+        "--mgmt-slot",
+        type=int,
+        default=5,
+        help="CSR mgmt interface slot (default 5 -> GigabitEthernet5)",
+    )
+    args = parser.parse_args()
+
+    global MGMT_IFACE_FILTER
+    MGMT_IFACE_FILTER = f"GigabitEthernet{args.mgmt_slot}"
+
+    if args.mapping_file:
+        mapping = json.loads(args.mapping_file.read_text(encoding="utf-8"))
+        _patch_nac_files(args.nac_root, mapping)
+        report_path = args.nac_root / "mgmt_dhcp_sync.json"
+        report_path.write_text(
+            json.dumps({"synced": len(mapping), "mapping": mapping}, indent=2),
+            encoding="utf-8",
+        )
+        print(json.dumps({"synced": len(mapping), "report": str(report_path)}, indent=2))
+        return 0
+
+    if not args.lab_id:
+        print("--lab-id is required unless --mapping-file is provided", file=sys.stderr)
+        return 1
+
+    try:
+        from virl2_client import ClientLibrary
+    except ImportError:
+        print("virl2_client is required", file=sys.stderr)
+        return 1
+
+    url = os.environ.get("VIRL2_URL", "https://192.168.1.183")
+    user = os.environ.get("VIRL2_USER", "")
+    password = os.environ.get("VIRL2_PASS", "")
+    client = ClientLibrary(url, user, password, ssl_verify=False)
+    lab = client.join_existing_lab(args.lab_id)
+
+    mapping: dict[str, str] = {}
+    report: dict[str, object] = {
+        "lab_id": args.lab_id,
+        "nac_root": str(args.nac_root),
+        "mgmt_interface": MGMT_IFACE_FILTER,
+        "routers": {},
+    }
+
+    for node in lab.nodes():
+        if node.node_definition != "csr1000v":
+            continue
+        label = node.label
+        if not label.startswith("R") or not label[1:].isdigit():
+            continue
+        index = int(label[1:])
+        canonical = _canonical_name(index)
+        entry: dict[str, str | None] = {"state": str(node.state), "mgmt_ip": None, "error": None}
+
+        if str(node.state) != "BOOTED":
+            report["routers"][label] = entry
+            continue
+
+        try:
+            if args.fix_dhcp:
+                node.run_pyats_config_command(
+                    DHCP_FIX_COMMANDS.replace("GigabitEthernet5", MGMT_IFACE_FILTER)
+                )
+            show_cmd = f"show ip interface brief | include {MGMT_IFACE_FILTER}"
+            output = node.run_pyats_command(show_cmd, config=False)
+            mgmt_ip = _parse_mgmt_ip(str(output))
+            entry["mgmt_ip"] = mgmt_ip
+            if mgmt_ip:
+                mapping[canonical] = mgmt_ip
+        except Exception as exc:  # noqa: BLE001 - surface per-node CML/pyATS failures
+            entry["error"] = str(exc)
+
+        report["routers"][label] = entry
+
+    if mapping:
+        _patch_nac_files(args.nac_root, mapping)
+
+    report["synced"] = len(mapping)
+    report_path = args.nac_root / "mgmt_dhcp_sync.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({"synced": len(mapping), "report": str(report_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/topogen/nac.py
+++ b/src/topogen/nac.py
@@ -173,7 +173,11 @@ def _select_host(node: TopogenNode, args) -> str:
         for iface in node_interfaces:
             description = str(_get_iface_value(iface, "description", ""))
             if description == "OOB Management":
-                return _normalize_ipv4_host(_get_iface_value(iface, "address", None))
+                address = _get_iface_value(iface, "address", None)
+                if address:
+                    return _normalize_ipv4_host(address)
+                if bool(getattr(args, "mgmt_bridge", False)):
+                    return ""
         return ""
 
     data_interfaces = sorted(

--- a/src/topogen/render.py
+++ b/src/topogen/render.py
@@ -692,11 +692,15 @@ def _append_nac_mgmt_interface(node: TopogenNode, args: Namespace, router_index:
     mgmt_slot = int(getattr(args, "mgmt_slot", 5))
     dev_def = str(getattr(args, "dev_template", getattr(args, "template", ""))).lower()
     model_slot = mgmt_slot - 1 if dev_def == "csr1000v" else mgmt_slot
+    mgmt_bridge = bool(getattr(args, "mgmt_bridge", False))
+    mgmt_address = None
+    if not mgmt_bridge:
+        mgmt_address = IPv4Interface(
+            f"{mgmt_net.network_address + router_index}/{mgmt_net.prefixlen}"
+        )
     node.interfaces.append(
         TopogenInterface(
-            address=IPv4Interface(
-                f"{mgmt_net.network_address + router_index}/{mgmt_net.prefixlen}"
-            ),
+            address=mgmt_address,
             vrf=getattr(args, "mgmt_vrf", None),
             description="OOB Management",
             slot=model_slot,

--- a/src/topogen/templates/csr-eigrp.jinja2
+++ b/src/topogen/templates/csr-eigrp.jinja2
@@ -26,7 +26,7 @@ username {{ config.username }} privilege 15 secret {{ config.password }}
 cdp run
 !
 {%- set ns = namespace(seen={}) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 {%- if iface.vrf and not ns.seen.get(iface.vrf) %}
 vrf definition {{ iface.vrf }}
  rd 1:1
@@ -71,7 +71,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -83,13 +83,13 @@ router eigrp 100
  eigrp stub connected summary
  {%- endif %}
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
@@ -167,7 +167,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr-eigrp.jinja2
+++ b/src/topogen/templates/csr-eigrp.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.3.0
-# Date Modified: 2026-02-25
+# Doc Version: v1.3.1
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp)
@@ -90,7 +90,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}
@@ -168,7 +168,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-getvpn-ks.jinja2
+++ b/src/topogen/templates/csr-getvpn-ks.jinja2
@@ -7,8 +7,8 @@
 #            This template uses CSR-style interface names (GigabitEthernet1, not Gi0/1).
 #
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.0.1
-# Date Modified: 2026-03-20
+# Doc Version: v1.0.2
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (offline renderers)
 # - Reads from: Jinja context (config, node, getvpn_*, mgmt, ntp, archive)
@@ -187,7 +187,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}
@@ -270,7 +270,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-getvpn-ks.jinja2
+++ b/src/topogen/templates/csr-getvpn-ks.jinja2
@@ -171,7 +171,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -180,13 +180,13 @@ router eigrp TOPGEN
 {%- else %}
 router eigrp 100
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
@@ -269,7 +269,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr-ospf.jinja2
+++ b/src/topogen/templates/csr-ospf.jinja2
@@ -68,11 +68,11 @@ int Loopback0
 router ospf 1
     passive-interface Loopback0
     network {{ node.loopback.ip }} 0.0.0.0 area 0
-{%- for iface in node.interfaces if iface.address %}
+{%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
     network {{ iface.address.ip }} 0.0.0.0 area 0
 {%- endfor %}
 !
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
@@ -150,7 +150,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr-ospf.jinja2
+++ b/src/topogen/templates/csr-ospf.jinja2
@@ -4,8 +4,8 @@
 #          Used for both regular routers and PKI CA when --pki flag is enabled.
 #
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.3.0
-# Date Modified: 2026-02-25
+# Doc Version: v1.3.1
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step in offline_flat_yaml)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp)
@@ -73,7 +73,7 @@ router ospf 1
 {%- endfor %}
 !
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}
@@ -151,7 +151,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-pki-ca.jinja2
+++ b/src/topogen/templates/csr-pki-ca.jinja2
@@ -8,8 +8,8 @@
 #            Future TODO: Support IOSv if PKI server works on IOSv platform.
 #
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.3.4
-# Date Modified: 2026-03-24
+# Doc Version: v1.3.5
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step in offline_flat_yaml)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, pki_enabled)
@@ -121,7 +121,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if loop.first %}
     description === SCEP Enrollment URL ===
     {%- elif iface.description %}
@@ -233,7 +233,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
- action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
+ action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ iface.slot + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}
 {%- endfor %}

--- a/src/topogen/templates/csr-pki-ca.jinja2
+++ b/src/topogen/templates/csr-pki-ca.jinja2
@@ -102,7 +102,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -114,13 +114,13 @@ router eigrp 100
  eigrp stub connected summary
  {%- endif %}
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if loop.first %}
     description === SCEP Enrollment URL ===
@@ -232,7 +232,7 @@ event manager applet TOPOGEN-NOSHUT authorization bypass
  action 1.1 cli command "terminal length 0"
  action 1.2 cli command "config t"
 {%- set ns_eem = namespace(n=2) %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
  action {{ ns_eem.n }}.0 cli command "interface GigabitEthernet{{ loop.index0 + 1 }}"
  action {{ ns_eem.n }}.1 cli command "no shutdown"
 {%- set ns_eem.n = ns_eem.n + 1 %}

--- a/src/topogen/templates/csr1000v.jinja2
+++ b/src/topogen/templates/csr1000v.jinja2
@@ -64,7 +64,7 @@ router ospf 2 vrf {{ iface.vrf }}
 !
 {%- endif %}
 {%- endfor %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet{{ loop.index0 + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/csr1000v.jinja2
+++ b/src/topogen/templates/csr1000v.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.0.0
-# Date Modified: 2026-06-03
+# Doc Version: v1.0.1
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: origin, mgmt, ntp, ntp_oob, archive)
@@ -65,7 +65,7 @@ router ospf 2 vrf {{ iface.vrf }}
 {%- endif %}
 {%- endfor %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet{{ loop.index0 + 1 }}
+interface GigabitEthernet{{ iface.slot + 1 }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv-eigrp-nonflat.jinja2
+++ b/src/topogen/templates/iosv-eigrp-nonflat.jinja2
@@ -38,7 +38,7 @@ router eigrp 100
     network 172.16.0.0 0.15.255.255
     no auto-summary
 !
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/iosv-eigrp-nonflat.jinja2
+++ b/src/topogen/templates/iosv-eigrp-nonflat.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.3
-# Date Modified: 2026-03-23
+# Doc Version: v1.1.4
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, ntp_oob, archive)
@@ -39,7 +39,7 @@ router eigrp 100
     no auto-summary
 !
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv-eigrp-stub.jinja2
+++ b/src/topogen/templates/iosv-eigrp-stub.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.3
-# Date Modified: 2026-03-23
+# Doc Version: v1.1.4
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, ntp_oob, eigrp_stub, archive)
@@ -84,7 +84,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv-eigrp-stub.jinja2
+++ b/src/topogen/templates/iosv-eigrp-stub.jinja2
@@ -68,7 +68,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -77,13 +77,13 @@ router eigrp TOPGEN
 {%- else %}
 router eigrp 100
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/iosv-eigrp.jinja2
+++ b/src/topogen/templates/iosv-eigrp.jinja2
@@ -68,7 +68,7 @@ router eigrp TOPGEN
   !
   topology base
   exit-af-topology
-  {%- for iface in node.interfaces if iface.address and not iface.vrf %}
+  {%- for iface in node.interfaces if iface.address and not iface.vrf and (iface.description | default('')) != 'OOB Management' %}
   network {{ iface.address.ip }} 0.0.0.0
   {%- endfor %}
   network {{ node.loopback.ip }} 0.0.0.0
@@ -80,13 +80,13 @@ router eigrp 100
  eigrp stub connected summary
  {%- endif %}
  network {{ node.loopback.ip }} 0.0.0.0
- {%- for iface in node.interfaces if iface.address %}
+ {%- for iface in node.interfaces if iface.address and (iface.description | default('')) != 'OOB Management' %}
  network {{ iface.address.ip }} 0.0.0.0
  {%- endfor %}
  passive-interface Loopback0
 !
 {%- endif %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/src/topogen/templates/iosv-eigrp.jinja2
+++ b/src/topogen/templates/iosv-eigrp.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.1
-# Date Modified: 2026-02-16
+# Doc Version: v1.1.2
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: mgmt, ntp, eigrp_stub)
@@ -87,7 +87,7 @@ router eigrp 100
 !
 {%- endif %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv.jinja2
+++ b/src/topogen/templates/iosv.jinja2
@@ -1,6 +1,6 @@
 {# File Chain (see DEVELOPER.md):
-# Doc Version: v1.1.3
-# Date Modified: 2026-03-23
+# Doc Version: v1.1.4
+# Date Modified: 2026-06-08
 #
 # - Called by: src/topogen/render.py (Jinja render step)
 # - Reads from: Jinja context (config, node, plus feature flags: origin, mgmt, ntp, ntp_oob, archive)
@@ -63,7 +63,7 @@ router ospf 2 vrf {{ iface.vrf }}
 {%- endif %}
 {%- endfor %}
 {%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
-interface GigabitEthernet0/{{ loop.index0 }}
+interface GigabitEthernet0/{{ iface.slot }}
     {%- if iface.description %}
     description {{ iface.description }}
     {%- endif %}

--- a/src/topogen/templates/iosv.jinja2
+++ b/src/topogen/templates/iosv.jinja2
@@ -62,7 +62,7 @@ router ospf 2 vrf {{ iface.vrf }}
 !
 {%- endif %}
 {%- endfor %}
-{%- for iface in node.interfaces %}
+{%- for iface in node.interfaces if (iface.description | default('')) != 'OOB Management' %}
 interface GigabitEthernet0/{{ loop.index0 }}
     {%- if iface.description %}
     description {{ iface.description }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+# File Chain (see DEVELOPER.md):
+# Doc Version: v1.0.0
+# Date Modified: 2026-06-08
+#
+# - Called by: pytest (tests/test_nac_terraform_plan.py)
+# - Reads from: TOPOGEN_TERRAFORM_PLAN env, pytest -m selection
+# - Writes to: None
+#
+# Purpose: Opt-in collection rules for NaC terraform plan contract tests (TG-161).
+# Blast Radius: Test-only.
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "terraform: NaC terraform init/plan contract (needs terraform binary + network)",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    run_terraform = os.environ.get("TOPOGEN_TERRAFORM_PLAN") == "1"
+    markexpr = config.getoption("-m", default="")
+    if run_terraform or (markexpr and "terraform" in markexpr):
+        return
+
+    skip = pytest.mark.skip(
+        reason=(
+            "terraform plan gate is opt-in: set TOPOGEN_TERRAFORM_PLAN=1 "
+            "or run pytest -m terraform"
+        )
+    )
+    for item in items:
+        if "terraform" in item.keywords:
+            item.add_marker(skip)

--- a/tests/test_nac_terraform_plan.py
+++ b/tests/test_nac_terraform_plan.py
@@ -1,0 +1,215 @@
+# File Chain (see DEVELOPER.md):
+# Doc Version: v1.0.0
+# Date Modified: 2026-06-08
+#
+# - Called by: Developers/CI via pytest -m terraform (TG-161)
+# - Reads from: src/topogen/main.py offline renderer, terraform CLI
+# - Writes to: Short-path temporary directories only
+# - Calls into: topogen.main.main, terraform init/plan
+#
+# Purpose: Contract-test generated NaC workspaces against netascode/nac-iosxe via terraform plan.
+# Blast Radius: Test-only; no runtime behavior changes.
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from topogen.main import main  # pylint: disable=wrong-import-position
+
+
+PLAN_ADD_RE = re.compile(r"Plan: \d+ to add, 0 to change, 0 to destroy\.")
+FAIL_PATTERNS = (
+    re.compile(r"Unsupported attribute", re.IGNORECASE),
+    re.compile(r"^Error:", re.MULTILINE),
+)
+
+DUMMY_IOSXE_ENV = {
+    "IOSXE_USERNAME": "lab",
+    "IOSXE_PASSWORD": "lab",
+    "IOSXE_URL": "https://127.0.0.1",
+}
+
+
+@dataclass(frozen=True)
+class NacTerraformCase:
+    case_id: str
+    argv: tuple[str, ...]
+
+
+NAC_TERRAFORM_MATRIX: tuple[NacTerraformCase, ...] = (
+    NacTerraformCase("flat-iosv", ("2", "--mode", "flat")),
+    NacTerraformCase("flat-pair-iosv", ("2", "--mode", "flat-pair")),
+    NacTerraformCase(
+        "dmvpn-flat-iosv",
+        ("3", "--mode", "dmvpn", "--dmvpn-hubs", "1"),
+    ),
+    NacTerraformCase(
+        "dmvpn-flat-pair-iosv",
+        (
+            "4",
+            "--mode",
+            "dmvpn",
+            "--dmvpn-underlay",
+            "flat-pair",
+            "--template",
+            "iosv-dmvpn",
+        ),
+    ),
+    NacTerraformCase(
+        "flat-csr",
+        ("2", "--mode", "flat", "-T", "csr-ospf", "--device-template", "csr1000v"),
+    ),
+    NacTerraformCase(
+        "flat-pair-csr",
+        ("2", "--mode", "flat-pair", "-T", "csr-ospf", "--device-template", "csr1000v"),
+    ),
+    NacTerraformCase(
+        "dmvpn-flat-csr",
+        (
+            "3",
+            "--mode",
+            "dmvpn",
+            "--dmvpn-hubs",
+            "1",
+            "-T",
+            "csr-ospf",
+            "--device-template",
+            "csr1000v",
+        ),
+    ),
+    NacTerraformCase(
+        "dmvpn-flat-pair-csr",
+        (
+            "4",
+            "--mode",
+            "dmvpn",
+            "--dmvpn-underlay",
+            "flat-pair",
+            "--template",
+            "csr-dmvpn",
+            "--device-template",
+            "csr1000v",
+        ),
+    ),
+)
+
+
+def short_temp_base() -> Path:
+    if sys.platform == "win32":
+        for candidate in (Path("C:/t"), Path("C:/tmp")):
+            try:
+                candidate.mkdir(parents=True, exist_ok=True)
+                return candidate
+            except OSError:
+                continue
+    return Path(tempfile.gettempdir())
+
+
+def _run_topogen(argv: list[str]) -> int:
+    with patch.object(sys, "argv", ["topogen", *argv]):
+        return main()
+
+
+def _assert_plan_output(combined: str) -> None:
+    for pattern in FAIL_PATTERNS:
+        match = pattern.search(combined)
+        assert match is None, f"terraform plan failure pattern {pattern.pattern!r}: {match.group(0)}"
+    assert PLAN_ADD_RE.search(combined), f"expected 'Plan: N to add' in output:\n{combined[-4000:]}"
+
+
+def _terraform_run(
+    nac_dir: Path,
+    args: list[str],
+    *,
+    env: dict[str, str],
+    terraform_binary: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [terraform_binary, *args],
+        cwd=nac_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def terraform_binary() -> str:
+    path = shutil.which("terraform")
+    if not path:
+        pytest.skip("terraform binary not found on PATH")
+    return path
+
+
+@pytest.fixture(scope="session")
+def tf_plugin_cache_dir() -> Path:
+    cache = short_temp_base() / "topogen-tf-plugin-cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+@pytest.mark.terraform
+@pytest.mark.parametrize("case", NAC_TERRAFORM_MATRIX, ids=lambda item: item.case_id)
+def test_nac_workspace_terraform_plan(
+    case: NacTerraformCase,
+    terraform_binary: str,
+    tf_plugin_cache_dir: Path,
+) -> None:
+    work_root = Path(tempfile.mkdtemp(dir=str(short_temp_base()), prefix="tg161-"))
+    try:
+        lab_name = case.case_id
+        out_yaml = work_root / f"{lab_name}.yaml"
+        argv = [
+            *case.argv,
+            "--offline-yaml",
+            str(out_yaml),
+            "--nac",
+            "--overwrite",
+        ]
+        rc = _run_topogen(argv)
+        assert rc == 0, f"topogen failed for {case.case_id}"
+
+        nac_dir = work_root / lab_name / "nac"
+        assert (nac_dir / "main.tf").is_file(), f"missing terraform scaffold for {case.case_id}"
+        assert (nac_dir / "nac.yaml").is_file(), f"missing nac.yaml for {case.case_id}"
+
+        env = os.environ.copy()
+        env.update(DUMMY_IOSXE_ENV)
+        env["TF_PLUGIN_CACHE_DIR"] = str(tf_plugin_cache_dir)
+
+        init = _terraform_run(
+            nac_dir,
+            ["init", "-input=false", "-no-color"],
+            env=env,
+            terraform_binary=terraform_binary,
+        )
+        init_out = init.stdout + init.stderr
+        assert init.returncode == 0, f"terraform init failed for {case.case_id}:\n{init_out}"
+
+        plan = _terraform_run(
+            nac_dir,
+            ["plan", "-input=false", "-no-color"],
+            env=env,
+            terraform_binary=terraform_binary,
+        )
+        plan_out = plan.stdout + plan.stderr
+        assert plan.returncode == 0, f"terraform plan failed for {case.case_id}:\n{plan_out}"
+        _assert_plan_output(plan_out)
+    finally:
+        shutil.rmtree(work_root, ignore_errors=True)

--- a/tests/test_nac_writer.py
+++ b/tests/test_nac_writer.py
@@ -1,6 +1,6 @@
 # File Chain (see DEVELOPER.md):
-# Doc Version: v1.15.0
-# Date Modified: 2026-06-04
+# Doc Version: v1.16.0
+# Date Modified: 2026-06-08
 #
 # - Called by: Developers/CI via unittest discovery
 # - Reads from: src/topogen/main.py, src/topogen/nac.py
@@ -10,15 +10,18 @@
 # Purpose: Verify canonical NaC writer output layout, keys, deterministic rerun behavior, and DMVPN artifact paths.
 # Blast Radius: Test-only; no runtime behavior changes.
 
+import re
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from ipaddress import IPv4Interface
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import yaml
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +29,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from topogen.config import Config  # pylint: disable=wrong-import-position
 from topogen.main import main  # pylint: disable=wrong-import-position
 from topogen.models import TopogenInterface, TopogenNode  # pylint: disable=wrong-import-position
 from topogen.nac import (  # pylint: disable=wrong-import-position
@@ -40,6 +44,23 @@ from topogen.nac import (  # pylint: disable=wrong-import-position
     write_terraform_scaffold,
     write_verify_reachability_yaml,
 )
+
+
+def _extract_day0_config(node: dict) -> str:
+    cfg = node.get("configuration", "")
+    if isinstance(cfg, list):
+        return cfg[0].get("content", "") if cfg else ""
+    return cfg
+
+
+def _interface_names(config: str) -> list[str]:
+    return re.findall(r"^interface (GigabitEthernet\S+)$", config, re.MULTILINE)
+
+
+def _interface_stanza(config: str, iface_name: str) -> str:
+    pattern = rf"^interface {re.escape(iface_name)}$(.*?)(?=^interface |\nend\n|\Z)"
+    match = re.search(pattern, config, re.MULTILINE | re.DOTALL)
+    return match.group(0) if match else ""
 
 
 class TestNacWriter(unittest.TestCase):
@@ -1017,6 +1038,128 @@ class TestNacWriter(unittest.TestCase):
             ],
         )
         self.assertFalse(any(iface.get("description") == "OOB Management" for iface in ethernets))
+
+    def _high_degree_csr_node(self) -> TopogenNode:
+        return TopogenNode(
+            hostname="R5",
+            loopback=IPv4Interface("10.0.0.5/32"),
+            interfaces=[
+                TopogenInterface(address=IPv4Interface("172.16.0.14/30"), slot=0, description="to R1"),
+                TopogenInterface(
+                    address=None,
+                    vrf="Mgmt-vrf",
+                    description="OOB Management",
+                    slot=4,
+                ),
+                TopogenInterface(address=IPv4Interface("172.16.0.73/30"), slot=5, description="to R12"),
+                TopogenInterface(address=IPv4Interface("172.16.0.65/30"), slot=6, description="to R16"),
+            ],
+        )
+
+    def test_csr_day0_uses_topo_slot_not_loop_index(self):
+        """TG-169: CSR data-plane Gi numbers must follow iface.slot + 1 after mgmt skip."""
+        env = Environment(loader=PackageLoader("topogen"), autoescape=select_autoescape())
+        tpl = env.get_template("csr-ospf.jinja2")
+        node = self._high_degree_csr_node()
+        rendered = tpl.render(
+            config=Config(),
+            node=node,
+            date=datetime.now(timezone.utc),
+            mgmt={"enabled": True, "slot": 5, "vrf": "Mgmt-vrf", "gw": None},
+        )
+        names = _interface_names(rendered)
+        self.assertEqual(names.count("GigabitEthernet5"), 1)
+        gi5 = _interface_stanza(rendered, "GigabitEthernet5")
+        self.assertIn("ip address dhcp", gi5)
+        self.assertIn("OOB Management", gi5)
+        gi6 = _interface_stanza(rendered, "GigabitEthernet6")
+        self.assertIn("172.16.0.73", gi6)
+        self.assertIn("to R12", gi6)
+        gi7 = _interface_stanza(rendered, "GigabitEthernet7")
+        self.assertIn("172.16.0.65", gi7)
+        self.assertIn("network 172.16.0.73 0.0.0.0 area 0", rendered)
+        self.assertIn("network 172.16.0.65 0.0.0.0 area 0", rendered)
+        self.assertNotRegex(rendered, r"interface GigabitEthernet5\n.*ip address 172\.16")
+
+    def test_iosv_day0_uses_topo_slot_not_loop_index(self):
+        """TG-169: IOSv data-plane Gi numbers must follow iface.slot after mgmt skip."""
+        env = Environment(loader=PackageLoader("topogen"), autoescape=select_autoescape())
+        tpl = env.get_template("iosv.jinja2")
+        node = TopogenNode(
+            hostname="R5",
+            loopback=IPv4Interface("10.0.0.5/32"),
+            interfaces=[
+                TopogenInterface(address=IPv4Interface("172.16.0.14/30"), slot=0, description="to R1"),
+                TopogenInterface(
+                    address=None,
+                    vrf="Mgmt-vrf",
+                    description="OOB Management",
+                    slot=5,
+                ),
+                TopogenInterface(address=IPv4Interface("172.16.0.73/30"), slot=6, description="to R12"),
+            ],
+        )
+        rendered = tpl.render(
+            config=Config(),
+            node=node,
+            date=datetime.now(timezone.utc),
+            mgmt={"enabled": True, "slot": 5, "vrf": "Mgmt-vrf", "gw": None},
+        )
+        names = _interface_names(rendered)
+        self.assertEqual(names.count("GigabitEthernet0/5"), 1)
+        gi5 = _interface_stanza(rendered, "GigabitEthernet0/5")
+        self.assertIn("ip address dhcp", gi5)
+        gi6 = _interface_stanza(rendered, "GigabitEthernet0/6")
+        self.assertIn("172.16.0.73", gi6)
+        self.assertNotRegex(rendered, r"interface GigabitEthernet0/5\n.*ip address 172\.16")
+
+    def test_nx_mgmt_bridge_offline_yaml_no_duplicate_csr_gi5(self):
+        """TG-169: nx + mgmt-bridge CSR day-0 must not double-book Gi5 on high-degree nodes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out_file = Path(tmp) / "out" / "nx-mgmt-bridge-csr.yaml"
+            rc = self._run_main(
+                [
+                    "10",
+                    "--mode",
+                    "nx",
+                    "-T",
+                    "csr-ospf",
+                    "--device-template",
+                    "csr1000v",
+                    "--offline-yaml",
+                    str(out_file),
+                    "--mgmt",
+                    "--mgmt-bridge",
+                    "--mgmt-slot",
+                    "5",
+                    "--overwrite",
+                ]
+            )
+            self.assertEqual(rc, 0)
+            lab = yaml.safe_load(out_file.read_text(encoding="utf-8"))
+            routers = [
+                node
+                for node in lab["nodes"]
+                if node.get("node_definition") == "csr1000v"
+                and node.get("label", "").startswith("R")
+            ]
+            self.assertGreaterEqual(len(routers), 10)
+            for router in routers:
+                config = _extract_day0_config(router)
+                names = _interface_names(config)
+                self.assertEqual(len(names), len(set(names)), router["label"])
+                self.assertLessEqual(names.count("GigabitEthernet5"), 1, router["label"])
+                if "GigabitEthernet5" in names:
+                    gi5 = _interface_stanza(config, "GigabitEthernet5")
+                    self.assertIn("ip address dhcp", gi5, router["label"])
+                    self.assertNotRegex(
+                        config,
+                        r"interface GigabitEthernet5\n.*ip address 172\.16",
+                        router["label"],
+                    )
+                busy = [name for name in names if name not in {"GigabitEthernet5", "Loopback0"}]
+                if len(busy) >= 5:
+                    self.assertIn("GigabitEthernet6", names, router["label"])
 
     def test_flat_pair_cli_vrf_reaches_nac_output(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_nac_writer.py
+++ b/tests/test_nac_writer.py
@@ -983,6 +983,41 @@ class TestNacWriter(unittest.TestCase):
         self.assertNotIn("vrfs", config)
         self.assertNotIn("vrf_forwarding", config["interfaces"]["ethernets"][0])
 
+    def test_csr_mgmt_emits_post_oob_data_interfaces(self):
+        """CSR Gi6+ data links must be Terraform-managed; only OOB Gi5 is excluded."""
+        node = TopogenNode(
+            hostname="R5",
+            loopback=IPv4Interface("10.0.0.5/32"),
+            interfaces=[
+                TopogenInterface(address=IPv4Interface("172.16.0.14/30"), slot=0, description="to R1"),
+                TopogenInterface(
+                    address=None,
+                    vrf="Mgmt-vrf",
+                    description="OOB Management",
+                    slot=4,
+                ),
+                TopogenInterface(address=IPv4Interface("172.16.0.73/30"), slot=5, description="to R12"),
+                TopogenInterface(address=IPv4Interface("172.16.0.65/30"), slot=6, description="to R16"),
+            ],
+        )
+        model = build_canonical_nac_model(
+            node,
+            device_template="csr1000v",
+            template="csr-eigrp",
+            mode="nx",
+            args=SimpleNamespace(enable_mgmt=True, mgmt_slot=5, mgmt_bridge=True),
+        )
+        ethernets = model["iosxe"]["devices"][0]["configuration"]["interfaces"]["ethernets"]
+        self.assertEqual(
+            [(iface["id"], iface.get("description")) for iface in ethernets],
+            [
+                ("1", "to R1"),
+                ("6", "to R12"),
+                ("7", "to R16"),
+            ],
+        )
+        self.assertFalse(any(iface.get("description") == "OOB Management" for iface in ethernets))
+
     def test_flat_pair_cli_vrf_reaches_nac_output(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_file = Path(tmp) / "out" / "flat-pair-vrf.yaml"


### PR DESCRIPTION
## Summary
- Add opt-in pytest harness (`tests/test_nac_terraform_plan.py`) that generates eight offline NaC labs (flat, flat-pair, DMVPN flat/flat-pair × IOSv/CSR) and runs `terraform init` + `terraform plan -input=false` with dummy IOSXE env vars.
- Wire CI job **NaC Terraform plan contract** in `.github/workflows/python-package.yml` (path-filtered on NaC-related changes, warmed `TF_PLUGIN_CACHE_DIR`).
- Document local workflow in DEVELOPER.md; mark TG-161 done in TODO.md/CHANGES.md.

Closes TG-161.

## Test plan
- [x] `TOPOGEN_TERRAFORM_PLAN=1 python -m pytest tests/test_nac_terraform_plan.py -m terraform` — **8/8 passed** locally (~2m20s)
- [x] Default `pytest` skips terraform tests (opt-in only)
- [ ] CI **NaC Terraform plan contract** job green on this PR
