### PR TITLE
Add CML2 terraform plan CI gate (40-case matrix)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       nac: ${{ steps.filter.outputs.nac }}
+      cml2: ${{ steps.filter.outputs.cml2 }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -34,6 +35,15 @@ jobs:
               - 'tests/test_nac_*.py'
               - 'tests/conftest.py'
               - 'tests/fixtures/nac/**'
+              - '.github/workflows/python-package.yml'
+            cml2:
+              - 'src/topogen/cml2.py'
+              - 'src/topogen/main.py'
+              - 'src/topogen/render.py'
+              - 'tests/offline_flag_matrix.py'
+              - 'tests/test_cml2_*.py'
+              - 'tests/conftest.py'
+              - 'scripts/validate-cml2-offline-matrix.py'
               - '.github/workflows/python-package.yml'
 
   build:
@@ -125,3 +135,44 @@ jobs:
         run: |
           mkdir -p "$TF_PLUGIN_CACHE_DIR"
           uv run pytest tests/test_nac_terraform_plan.py -m terraform -v
+
+  cml2-terraform-plan:
+    name: "CML2 Terraform plan contract"
+    needs: changes
+    if: needs.changes.outputs.cml2 == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.8.0"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "0.7.9"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache Terraform provider/module downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: cml2-tf-plugins-${{ runner.os }}-${{ hashFiles('src/topogen/cml2.py') }}
+          restore-keys: |
+            cml2-tf-plugins-${{ runner.os }}-
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run CML2 terraform plan matrix (40 cases)
+        env:
+          TOPOGEN_CML2_TERRAFORM_PLAN: "1"
+          TF_PLUGIN_CACHE_DIR: ${{ runner.temp }}/terraform-plugin-cache
+        run: |
+          mkdir -p "$TF_PLUGIN_CACHE_DIR"
+          uv run pytest tests/test_cml2_terraform_plan.py -m cml2_terraform -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ dev = [
 [tool.pytest.ini_options]
 markers = [
   "terraform: NaC terraform init/plan contract (needs terraform binary + network)",
+  "cml2_terraform: CML2 terraform init/plan contract (needs terraform binary + network)",
 ]
 
 [[tool.mypy.overrides]]

--- a/scripts/generate-offline-flag-matrix.py
+++ b/scripts/generate-offline-flag-matrix.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Generate the offline flag matrix (1000+ guardrail-valid cases)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TESTS = REPO / "tests"
+sys.path.insert(0, str(TESTS))
+
+from offline_flag_matrix import OFFLINE_FLAG_MATRIX, matrix_summary  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate offline flag matrix artifacts.")
+    parser.add_argument(
+        "artifact_root",
+        nargs="?",
+        default=str(REPO / "out" / "offline-flag-matrix"),
+        help="Output root (one subdirectory per case)",
+    )
+    parser.add_argument("--limit", type=int, default=0, help="Generate at most N cases (0=all)")
+    parser.add_argument("--offset", type=int, default=0, help="Skip first N matrix cases")
+    parser.add_argument("--summary-only", action="store_true", help="Print matrix dimensions and exit")
+    args = parser.parse_args()
+
+    summary = matrix_summary()
+    print(f"Matrix: {summary['total_cases']} valid cases (after guardrail pruning)")
+    if args.summary_only:
+        return 0
+
+    dest = Path(args.artifact_root)
+    dest.mkdir(parents=True, exist_ok=True)
+    cases = OFFLINE_FLAG_MATRIX[args.offset :]
+    if args.limit > 0:
+        cases = cases[: args.limit]
+    print(f"Slice: offset={args.offset} count={len(cases)}")
+
+    failed: list[str] = []
+    for case in cases:
+        lab_root = dest / case.case_id
+        yaml_path = lab_root / f"{case.case_id}.yaml"
+        lab_root.mkdir(parents=True, exist_ok=True)
+        cmd = [sys.executable, "-m", "topogen", *case.topogen_argv(str(yaml_path))]
+        env = __import__("os").environ.copy()
+        env["PYTHONPATH"] = str(REPO / "src")
+        rc = subprocess.run(cmd, cwd=REPO, env=env, check=False).returncode
+        status = "OK" if rc == 0 else f"FAIL rc={rc}"
+        print(f"{status} {case.case_id}")
+        if rc != 0:
+            failed.append(case.case_id)
+
+    print(f"\nGenerated {len(cases) - len(failed)}/{len(cases)} under {dest}")
+    if failed:
+        print("Failed:", ", ".join(failed[:20]), ("..." if len(failed) > 20 else ""))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-cml2-offline-matrix.py
+++ b/scripts/validate-cml2-offline-matrix.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# File Chain (see DEVELOPER.md):
+# Doc Version: v1.0.0
+# Date Modified: 2026-06-10
+#
+# Purpose: CML2 offline validation — 40-case matrix with terraform init/plan gates.
+# Blast Radius: Validation script only (writes under out/cml2-offline-matrix/).
+
+"""Validate CML2 offline matrix: modes x devices x cml2 flag x nac on/off."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TESTS = REPO / "tests"
+if str(TESTS) not in sys.path:
+    sys.path.insert(0, str(TESTS))
+
+from offline_flag_matrix import (  # noqa: E402
+    CML2_OFFLINE_MATRIX,
+    CML2_SCAFFOLD_FILES,
+    SECRET_FORBIDDEN_IN_TF,
+)
+
+ARTIFACT_ROOT = REPO / "out" / "cml2-offline-matrix"
+
+PLAN_ADD_RE = re.compile(r"Plan: \d+ to add, 0 to change, 0 to destroy\.")
+FAIL_PATTERNS = (
+    re.compile(r"Unsupported attribute", re.IGNORECASE),
+    re.compile(r"^Error:", re.MULTILINE),
+)
+
+CML2_PLAN_VARS = (
+    "-var=address=https://127.0.0.1",
+    "-var=skip_verify=true",
+    "-var=token=plan-only",
+)
+
+
+def _terraform_binary() -> str | None:
+    return shutil.which("terraform")
+
+
+def _assert_plan_output(combined: str) -> tuple[bool, str]:
+    for pattern in FAIL_PATTERNS:
+        match = pattern.search(combined)
+        if match:
+            return False, f"failure pattern {pattern.pattern!r}: {match.group(0)}"
+    if not PLAN_ADD_RE.search(combined):
+        return False, "missing 'Plan: N to add, 0 to change, 0 to destroy.'"
+    if "cml2_lifecycle.lab" not in combined:
+        return False, "missing cml2_lifecycle.lab in plan output"
+    return True, ""
+
+
+def main() -> int:
+    ARTIFACT_ROOT.mkdir(parents=True, exist_ok=True)
+    failed: list[str] = []
+    passed = 0
+    terraform = _terraform_binary()
+    if not terraform:
+        print("ERROR: terraform binary not found on PATH")
+        return 1
+
+    env = os.environ.copy()
+    cache = env.get("TF_PLUGIN_CACHE_DIR")
+    if not cache:
+        cache_dir = REPO / "out" / ".tf-plugin-cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        env["TF_PLUGIN_CACHE_DIR"] = str(cache_dir)
+
+    def gate(name: str, ok: bool, detail: str = "") -> None:
+        nonlocal passed
+        if ok:
+            passed += 1
+            print(f"[PASS] {name}")
+        else:
+            failed.append(name + (f" ({detail})" if detail else ""))
+            print(f"[FAIL] {name}" + (f" ({detail})" if detail else ""))
+
+    for case in CML2_OFFLINE_MATRIX:
+        lab = case.case_id
+        lab_root = ARTIFACT_ROOT / lab
+        yaml_path = lab_root / f"{lab}.yaml"
+        cml2_root = lab_root / "cml2"
+        nac_root = lab_root / "nac"
+
+        cmd = [sys.executable, "-m", "topogen", *case.topogen_argv(str(yaml_path))]
+        rc = subprocess.run(cmd, cwd=REPO, check=False).returncode
+        gate(f"{lab} generate", rc == 0, f"rc={rc}")
+
+        if not yaml_path.is_file():
+            continue
+
+        for name in CML2_SCAFFOLD_FILES:
+            gate(f"{lab} cml2/{name}", (cml2_root / name).is_file())
+
+        gate(f"{lab} nac/ rule", nac_root.is_dir() == case.with_nac)
+        if case.with_nac:
+            gate(f"{lab} nac/nac.yaml", (nac_root / "nac.yaml").is_file())
+
+        yaml_text = yaml_path.read_text(encoding="utf-8")
+        gate(f"{lab} provenance", "--terraform-cml2" in yaml_text)
+
+        secret_ok = True
+        secret_detail = ""
+        for tf_file in cml2_root.glob("*.tf"):
+            content = tf_file.read_text(encoding="utf-8").lower()
+            for forbidden in SECRET_FORBIDDEN_IN_TF:
+                if forbidden in content:
+                    secret_ok = False
+                    secret_detail = f"{forbidden!r} in {tf_file.name}"
+                    break
+            if not secret_ok:
+                break
+        gate(f"{lab} secret-free tf", secret_ok, secret_detail)
+
+        init = subprocess.run(
+            [terraform, "init", "-input=false", "-no-color"],
+            cwd=cml2_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        init_out = init.stdout + init.stderr
+        gate(f"{lab} terraform init", init.returncode == 0, init_out[-500:] if init.returncode else "")
+
+        if init.returncode != 0:
+            continue
+
+        plan = subprocess.run(
+            [terraform, "plan", "-input=false", "-no-color", *CML2_PLAN_VARS],
+            cwd=cml2_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        plan_out = plan.stdout + plan.stderr
+        plan_ok, plan_detail = _assert_plan_output(plan_out)
+        if plan.returncode != 0:
+            plan_ok = False
+            plan_detail = plan_out[-500:] or f"rc={plan.returncode}"
+        gate(f"{lab} terraform plan", plan_ok, plan_detail)
+
+    print("\n=== Summary ===")
+    print(f"Passed gates: {passed}")
+    print(f"Failed gates: {len(failed)}")
+    print(f"Artifacts: {ARTIFACT_ROOT}")
+    if failed:
+        for item in failed:
+            print(f"  - {item}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-offline-flag-matrix.py
+++ b/scripts/validate-offline-flag-matrix.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Validate offline flag matrix generation gates."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TESTS = REPO / "tests"
+sys.path.insert(0, str(TESTS))
+
+from offline_flag_matrix import (  # noqa: E402
+    CML2_SCAFFOLD_FILES,
+    NAC_FILES,
+    OFFLINE_FLAG_MATRIX,
+    matrix_summary,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate offline flag matrix generation.")
+    parser.add_argument(
+        "artifact_root",
+        nargs="?",
+        default=str(REPO / "out" / "offline-flag-matrix"),
+        help="Matrix artifact root",
+    )
+    parser.add_argument("--generate", action="store_true", help="Run topogen before gating")
+    parser.add_argument("--limit", type=int, default=0, help="Validate at most N cases (0=all)")
+    args = parser.parse_args()
+
+    dest = Path(args.artifact_root)
+    cases = OFFLINE_FLAG_MATRIX if args.limit <= 0 else OFFLINE_FLAG_MATRIX[: args.limit]
+    print(f"Validating {len(cases)} of {matrix_summary()['total_cases']} matrix cases")
+
+    failed: list[str] = []
+    passed = 0
+
+    def gate(name: str, ok: bool, detail: str = "") -> None:
+        nonlocal passed
+        if ok:
+            passed += 1
+        else:
+            failed.append(name + (f" ({detail})" if detail else ""))
+
+    for case in cases:
+        lab = case.case_id
+        lab_root = dest / lab
+        yaml_path = lab_root / f"{lab}.yaml"
+
+        if args.generate:
+            lab_root.mkdir(parents=True, exist_ok=True)
+            cmd = [sys.executable, "-m", "topogen", *case.topogen_argv(str(yaml_path))]
+            env = __import__("os").environ.copy()
+            env["PYTHONPATH"] = str(REPO / "src")
+            rc = subprocess.run(cmd, cwd=REPO, env=env, check=False).returncode
+            gate(f"{lab} generate", rc == 0, f"rc={rc}")
+            if rc != 0:
+                continue
+
+        if not yaml_path.is_file():
+            gate(f"{lab} yaml", False, "missing")
+            continue
+
+        text = yaml_path.read_text(encoding="utf-8")
+        gate(f"{lab} yaml", True)
+        gate(f"{lab} version", bool(re.search(rf"version:\s*'?{re.escape(case.cml_version)}'?", text)))
+        want_spot = case.intent_spot
+        gate(f"{lab} intent-spot", ("label: INTENT-SPOT" in text) == want_spot)
+
+        has_cml2 = case.cml2_label != "no-cml2"
+        if has_cml2:
+            for name in CML2_SCAFFOLD_FILES:
+                gate(f"{lab} cml2/{name}", (lab_root / "cml2" / name).is_file())
+        else:
+            gate(f"{lab} no cml2/", not (lab_root / "cml2").exists())
+
+        nac_dir = lab_root / "nac"
+        if case.with_nac:
+            gate(f"{lab} nac/", nac_dir.is_dir())
+            for name in NAC_FILES:
+                gate(f"{lab} nac/{name}", (nac_dir / name).is_file())
+        else:
+            gate(f"{lab} no nac/", not nac_dir.exists())
+
+        if case.with_nac:
+            gate(f"{lab} provenance --nac", "--nac" in text)
+        if has_cml2:
+            gate(f"{lab} provenance cml2", "--terraform-cml2" in text or "--cml2" in text)
+
+    print(f"\n=== Summary ===")
+    print(f"Passed gates: {passed}")
+    print(f"Failed gates: {len(failed)}")
+    print(f"Artifacts: {dest}")
+    if failed:
+        for item in failed[:30]:
+            print(f"  - {item}")
+        if len(failed) > 30:
+            print(f"  ... and {len(failed) - 30} more")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@
 # - Reads from: TOPOGEN_TERRAFORM_PLAN env, pytest -m selection
 # - Writes to: None
 #
-# Purpose: Opt-in collection rules for NaC terraform plan contract tests (TG-161).
+# Purpose: Opt-in collection rules for NaC/CML2 terraform plan contract tests.
 # Blast Radius: Test-only.
 
 from __future__ import annotations
@@ -21,20 +21,36 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "terraform: NaC terraform init/plan contract (needs terraform binary + network)",
     )
+    config.addinivalue_line(
+        "markers",
+        "cml2_terraform: CML2 terraform init/plan contract (needs terraform binary + network)",
+    )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    run_terraform = os.environ.get("TOPOGEN_TERRAFORM_PLAN") == "1"
     markexpr = config.getoption("-m", default="")
-    if run_terraform or (markexpr and "terraform" in markexpr):
-        return
+    run_nac = os.environ.get("TOPOGEN_TERRAFORM_PLAN") == "1"
+    run_cml2 = os.environ.get("TOPOGEN_CML2_TERRAFORM_PLAN") == "1"
 
-    skip = pytest.mark.skip(
+    skip_nac = pytest.mark.skip(
         reason=(
-            "terraform plan gate is opt-in: set TOPOGEN_TERRAFORM_PLAN=1 "
+            "NaC terraform plan gate is opt-in: set TOPOGEN_TERRAFORM_PLAN=1 "
             "or run pytest -m terraform"
         )
     )
+    skip_cml2 = pytest.mark.skip(
+        reason=(
+            "CML2 terraform plan gate is opt-in: set TOPOGEN_CML2_TERRAFORM_PLAN=1 "
+            "or run pytest -m cml2_terraform"
+        )
+    )
+
     for item in items:
-        if "terraform" in item.keywords:
-            item.add_marker(skip)
+        if "cml2_terraform" in item.keywords:
+            if run_cml2 or (markexpr and "cml2_terraform" in markexpr):
+                continue
+            item.add_marker(skip_cml2)
+        elif "terraform" in item.keywords:
+            if run_nac or (markexpr and markexpr == "terraform"):
+                continue
+            item.add_marker(skip_nac)

--- a/tests/offline_flag_matrix.py
+++ b/tests/offline_flag_matrix.py
@@ -1,0 +1,236 @@
+# File Chain (see DEVELOPER.md):
+# Doc Version: v1.0.0
+# Date Modified: 2026-06-10
+#
+# - Called by: scripts/generate-offline-flag-matrix.py, scripts/validate-offline-flag-matrix.py
+# - Reads from: None
+# - Writes to: None
+#
+# Purpose: 1000+ case offline YAML flag matrix (guardrail-aware cross-product).
+# Blast Radius: Test/automation only.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+MODES = ("simple", "nx", "flat", "flat-pair", "dmvpn")
+DEVICES = ("iosv", "csr1000v")
+NODE_COUNT = "4"
+
+CML2_OPTIONS = (
+    ("no-cml2", ()),
+    ("cml2", ("--cml2",)),
+    ("terraform-cml2", ("--terraform-cml2",)),
+)
+
+NAC_OPTIONS = (
+    ("no-nac", False),
+    ("nac", True),
+)
+
+INTENT_OPTIONS = (
+    ("no-spot", False),
+    ("intent-spot", True),
+)
+
+CML_VERSIONS = ("0.3.0", "0.3.1")
+
+MGMT_OPTIONS = (
+    ("no-mgmt", ()),
+    ("mgmt", ("--mgmt",)),
+    ("mgmt-bridge", ("--mgmt", "--mgmt-bridge")),
+)
+
+# Mutually-scoped offline feature profiles (not a full cross-product of every flag).
+EXTRA_PROFILES = (
+    ("base", ()),
+    ("archive", ("--archive",)),
+    ("vrf", ("--vrf",)),
+    ("pki", ("--pki",)),
+    ("pki-no-staging", ("--pki", "--no-staging")),
+    ("bootstrap", ("--bootstrap",)),
+    ("blank", ("--blank",)),
+    ("print-up", ("--print-up-cmd",)),
+)
+
+CML2_SCAFFOLD_FILES = ("main.tf", "versions.tf", "variables.tf", "outputs.tf", ".gitignore")
+NAC_FILES = ("nac.yaml", "main.tf")
+
+
+@dataclass(frozen=True)
+class OfflineFlagCase:
+    case_id: str
+    mode: str
+    device: str
+    cml2_label: str
+    cml2_args: tuple[str, ...]
+    with_nac: bool
+    intent_spot: bool
+    cml_version: str
+    mgmt_label: str
+    mgmt_args: tuple[str, ...]
+    extra_label: str
+    extra_args: tuple[str, ...]
+
+    def topogen_argv(self, offline_yaml: str) -> list[str]:
+        argv: list[str] = [
+            NODE_COUNT,
+            "-m",
+            self.mode,
+            "--device-template",
+            self.device,
+            *self.cml2_args,
+            "--cml-version",
+            self.cml_version,
+            "--overwrite",
+            "-q",
+            "--offline-yaml",
+            offline_yaml,
+            *self.mgmt_args,
+            *self.extra_args,
+        ]
+        if self.with_nac:
+            argv.insert(argv.index("--cml-version"), "--nac")
+        if self.intent_spot:
+            argv.insert(argv.index("--cml-version"), "--intent-spot")
+        if self.mode == "dmvpn":
+            insert_at = argv.index("--cml-version")
+            argv[insert_at:insert_at] = ["--dmvpn-hubs", "1"]
+        return argv
+
+
+def _mgmt_has_oob(mgmt_args: tuple[str, ...]) -> bool:
+    return "--mgmt" in mgmt_args
+
+
+def is_valid_offline_case(
+    *,
+    mode: str,
+    with_nac: bool,
+    cml_version: str,
+    mgmt_args: tuple[str, ...],
+    extra_args: tuple[str, ...],
+) -> bool:
+    """Mirror topogen offline guardrails from main.py (subset for matrix pruning)."""
+    has_blank = "--blank" in extra_args
+    has_bootstrap = "--bootstrap" in extra_args
+    has_pki = "--pki" in extra_args
+    has_vrf = "--vrf" in extra_args
+    has_archive = "--archive" in extra_args
+    has_mgmt = _mgmt_has_oob(mgmt_args)
+
+    if has_blank and with_nac:
+        return False
+    if has_blank and mode == "dmvpn":
+        return False
+    if has_bootstrap:
+        if not with_nac or not has_mgmt or has_blank or has_pki:
+            return False
+    if "--mgmt-bridge" in mgmt_args and not has_mgmt:
+        return False
+    if has_vrf and mode != "flat-pair":
+        return False
+    if has_archive and mode not in ("flat", "flat-pair"):
+        return False
+    if has_pki and mode not in ("flat", "flat-pair", "dmvpn"):
+        return False
+    if has_pki and cml_version != "0.3.1":
+        return False
+    if mode == "dmvpn" and has_pki and with_nac:
+        # DMVPN+PKI offline NaC projection is a known gap; keep matrix to YAML/scaffold coverage.
+        pass
+    return True
+
+
+def _case_id(
+    mode: str,
+    device: str,
+    cml2_label: str,
+    nac_label: str,
+    intent_label: str,
+    cml_version: str,
+    mgmt_label: str,
+    extra_label: str,
+) -> str:
+    cv = cml_version.replace(".", "")
+    return f"{mode}-{NODE_COUNT}-{device}-cv{cv}-{cml2_label}-{nac_label}-{intent_label}-{mgmt_label}-{extra_label}"
+
+
+def build_offline_flag_matrix() -> tuple[OfflineFlagCase, ...]:
+    cases: list[OfflineFlagCase] = []
+    for mode in MODES:
+        for device in DEVICES:
+            for cml2_label, cml2_args in CML2_OPTIONS:
+                for nac_label, with_nac in NAC_OPTIONS:
+                    for intent_label, intent_spot in INTENT_OPTIONS:
+                        for cml_version in CML_VERSIONS:
+                            for mgmt_label, mgmt_args in MGMT_OPTIONS:
+                                for extra_label, extra_args in EXTRA_PROFILES:
+                                    if not is_valid_offline_case(
+                                        mode=mode,
+                                        with_nac=with_nac,
+                                        cml_version=cml_version,
+                                        mgmt_args=mgmt_args,
+                                        extra_args=extra_args,
+                                    ):
+                                        continue
+                                    case_id = _case_id(
+                                        mode,
+                                        device,
+                                        cml2_label,
+                                        nac_label,
+                                        intent_label,
+                                        cml_version,
+                                        mgmt_label,
+                                        extra_label,
+                                    )
+                                    cases.append(
+                                        OfflineFlagCase(
+                                            case_id=case_id,
+                                            mode=mode,
+                                            device=device,
+                                            cml2_label=cml2_label,
+                                            cml2_args=cml2_args,
+                                            with_nac=with_nac,
+                                            intent_spot=intent_spot,
+                                            cml_version=cml_version,
+                                            mgmt_label=mgmt_label,
+                                            mgmt_args=mgmt_args,
+                                            extra_label=extra_label,
+                                            extra_args=extra_args,
+                                        )
+                                    )
+    return tuple(cases)
+
+
+OFFLINE_FLAG_MATRIX: tuple[OfflineFlagCase, ...] = build_offline_flag_matrix()
+
+# Subset used by earlier CML2-only scripts (40 cases).
+CML2_OFFLINE_MATRIX = tuple(
+    case
+    for case in OFFLINE_FLAG_MATRIX
+    if case.cml_version == "0.3.1"
+    and case.mgmt_label == "no-mgmt"
+    and case.extra_label == "base"
+    and case.intent_spot is False
+    and case.cml2_label in ("cml2", "terraform-cml2")
+)
+
+
+def matrix_summary(cases: Iterable[OfflineFlagCase] = OFFLINE_FLAG_MATRIX) -> dict[str, int]:
+    items = list(cases)
+    return {
+        "total_cases": len(items),
+        "modes": len(MODES),
+        "devices": len(DEVICES),
+        "cml2_options": len(CML2_OPTIONS),
+        "nac_options": len(NAC_OPTIONS),
+        "intent_options": len(INTENT_OPTIONS),
+        "cml_versions": len(CML_VERSIONS),
+        "mgmt_options": len(MGMT_OPTIONS),
+        "extra_profiles": len(EXTRA_PROFILES),
+    }
+
+
+SECRET_FORBIDDEN_IN_TF = ("admin", "cisco123", "10.", "172.", "192.168.")

--- a/tests/test_cml2_terraform_plan.py
+++ b/tests/test_cml2_terraform_plan.py
@@ -1,0 +1,181 @@
+# File Chain (see DEVELOPER.md):
+# Doc Version: v1.0.0
+# Date Modified: 2026-06-10
+#
+# - Called by: Developers/CI via pytest -m cml2_terraform (TOPOGEN_CML2_TERRAFORM_PLAN=1)
+# - Reads from: tests/offline_flag_matrix.py, src/topogen/main.py, terraform CLI
+# - Writes to: Short-path temporary directories only
+# - Calls into: topogen.main.main, terraform init/plan
+#
+# Purpose: Contract-test generated CML2 workspaces via terraform plan (40-case matrix).
+# Blast Radius: Test-only; no runtime behavior changes.
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from offline_flag_matrix import (  # pylint: disable=wrong-import-position
+    CML2_OFFLINE_MATRIX,
+    CML2_SCAFFOLD_FILES,
+    SECRET_FORBIDDEN_IN_TF,
+    OfflineFlagCase as Cml2OfflineCase,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from topogen.main import main  # pylint: disable=wrong-import-position
+
+
+PLAN_ADD_RE = re.compile(r"Plan: \d+ to add, 0 to change, 0 to destroy\.")
+FAIL_PATTERNS = (
+    re.compile(r"Unsupported attribute", re.IGNORECASE),
+    re.compile(r"^Error:", re.MULTILINE),
+)
+
+CML2_PLAN_VARS = (
+    "-var=address=https://127.0.0.1",
+    "-var=skip_verify=true",
+    "-var=token=plan-only",
+)
+
+
+def short_temp_base() -> Path:
+    if sys.platform == "win32":
+        for candidate in (Path("C:/t"), Path("C:/tmp")):
+            try:
+                candidate.mkdir(parents=True, exist_ok=True)
+                return candidate
+            except OSError:
+                continue
+    return Path(tempfile.gettempdir())
+
+
+def _run_topogen(argv: list[str]) -> int:
+    with patch.object(sys, "argv", ["topogen", *argv]):
+        return main()
+
+
+def _assert_plan_output(combined: str) -> None:
+    for pattern in FAIL_PATTERNS:
+        match = pattern.search(combined)
+        assert match is None, f"terraform plan failure pattern {pattern.pattern!r}: {match.group(0)}"
+    assert PLAN_ADD_RE.search(combined), f"expected 'Plan: N to add' in output:\n{combined[-4000:]}"
+    assert "cml2_lifecycle.lab" in combined, (
+        f"expected cml2_lifecycle.lab in plan output:\n{combined[-4000:]}"
+    )
+
+
+def _assert_generation_artifacts(case: Cml2OfflineCase, lab_root: Path) -> None:
+    yaml_path = lab_root / f"{case.case_id}.yaml"
+    cml2_root = lab_root / "cml2"
+    nac_root = lab_root / "nac"
+
+    assert yaml_path.is_file(), f"missing YAML for {case.case_id}"
+    for name in CML2_SCAFFOLD_FILES:
+        assert (cml2_root / name).is_file(), f"missing cml2/{name} for {case.case_id}"
+
+    if case.with_nac:
+        assert nac_root.is_dir(), f"expected nac/ for {case.case_id}"
+        assert (nac_root / "nac.yaml").is_file()
+    else:
+        assert not nac_root.exists(), f"unexpected nac/ for {case.case_id}"
+
+    yaml_text = yaml_path.read_text(encoding="utf-8")
+    # --cml2 is a CLI alias for --terraform-cml2; provenance records the canonical flag.
+    assert "--terraform-cml2" in yaml_text, (
+        f"expected --terraform-cml2 in provenance for {case.case_id}"
+    )
+
+    for tf_file in cml2_root.glob("*.tf"):
+        content = tf_file.read_text(encoding="utf-8")
+        lowered = content.lower()
+        for forbidden in SECRET_FORBIDDEN_IN_TF:
+            assert forbidden not in lowered, (
+                f"forbidden pattern {forbidden!r} in {tf_file.name} for {case.case_id}"
+            )
+
+
+def _terraform_run(
+    cml2_dir: Path,
+    args: list[str],
+    *,
+    env: dict[str, str],
+    terraform_binary: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [terraform_binary, *args],
+        cwd=cml2_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def terraform_binary() -> str:
+    path = shutil.which("terraform")
+    if not path:
+        pytest.skip("terraform binary not found on PATH")
+    return path
+
+
+@pytest.fixture(scope="session")
+def tf_plugin_cache_dir() -> Path:
+    cache = short_temp_base() / "topogen-cml2-tf-plugin-cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+@pytest.mark.cml2_terraform
+@pytest.mark.parametrize("case", CML2_OFFLINE_MATRIX, ids=lambda item: item.case_id)
+def test_cml2_workspace_terraform_plan(
+    case: Cml2OfflineCase,
+    terraform_binary: str,
+    tf_plugin_cache_dir: Path,
+) -> None:
+    work_root = Path(tempfile.mkdtemp(dir=str(short_temp_base()), prefix="cml2-matrix-"))
+    try:
+        out_yaml = work_root / f"{case.case_id}.yaml"
+        rc = _run_topogen(case.topogen_argv(str(out_yaml)))
+        assert rc == 0, f"topogen failed for {case.case_id}"
+
+        lab_root = work_root / case.case_id
+        _assert_generation_artifacts(case, lab_root)
+
+        cml2_dir = lab_root / "cml2"
+        env = os.environ.copy()
+        env["TF_PLUGIN_CACHE_DIR"] = str(tf_plugin_cache_dir)
+
+        init = _terraform_run(
+            cml2_dir,
+            ["init", "-input=false", "-no-color"],
+            env=env,
+            terraform_binary=terraform_binary,
+        )
+        init_out = init.stdout + init.stderr
+        assert init.returncode == 0, f"terraform init failed for {case.case_id}:\n{init_out}"
+
+        plan = _terraform_run(
+            cml2_dir,
+            ["plan", "-input=false", "-no-color", *CML2_PLAN_VARS],
+            env=env,
+            terraform_binary=terraform_binary,
+        )
+        plan_out = plan.stdout + plan.stderr
+        assert plan.returncode == 0, f"terraform plan failed for {case.case_id}:\n{plan_out}"
+        _assert_plan_output(plan_out)
+    finally:
+        shutil.rmtree(work_root, ignore_errors=True)

--- a/tests/test_offline_flag_matrix.py
+++ b/tests/test_offline_flag_matrix.py
@@ -1,0 +1,80 @@
+# File Chain (see DEVELOPER.md):
+# Doc Version: v1.0.0
+# Date Modified: 2026-06-10
+#
+# Purpose: Offline flag matrix size and guardrail sanity checks.
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS = ROOT / "tests"
+sys.path.insert(0, str(TESTS))
+
+from offline_flag_matrix import (  # pylint: disable=wrong-import-position
+    CML2_OFFLINE_MATRIX,
+    OFFLINE_FLAG_MATRIX,
+    is_valid_offline_case,
+    matrix_summary,
+)
+
+
+class TestOfflineFlagMatrix(unittest.TestCase):
+    def test_matrix_has_at_least_1000_cases(self):
+        self.assertGreaterEqual(len(OFFLINE_FLAG_MATRIX), 1000)
+
+    def test_cml2_subset_is_40_cases(self):
+        self.assertEqual(len(CML2_OFFLINE_MATRIX), 40)
+
+    def test_case_ids_unique(self):
+        ids = [case.case_id for case in OFFLINE_FLAG_MATRIX]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_bootstrap_guardrail_pruned(self):
+        for case in OFFLINE_FLAG_MATRIX:
+            if "--bootstrap" in case.extra_args:
+                self.assertTrue(case.with_nac)
+                self.assertIn("--mgmt", case.mgmt_args)
+
+    def test_blank_guardrail_pruned(self):
+        for case in OFFLINE_FLAG_MATRIX:
+            if "--blank" in case.extra_args:
+                self.assertFalse(case.with_nac)
+                self.assertNotEqual(case.mode, "dmvpn")
+
+    def test_summary_matches_build(self):
+        summary = matrix_summary()
+        self.assertEqual(summary["total_cases"], len(OFFLINE_FLAG_MATRIX))
+
+    def test_is_valid_offline_case_rejects_nac_blank(self):
+        self.assertFalse(
+            is_valid_offline_case(
+                mode="flat",
+                with_nac=True,
+                cml_version="0.3.1",
+                mgmt_args=(),
+                extra_args=("--blank",),
+            )
+        )
+
+    def test_is_valid_offline_case_rejects_dmvpn_blank(self):
+        self.assertFalse(
+            is_valid_offline_case(
+                mode="dmvpn",
+                with_nac=False,
+                cml_version="0.3.1",
+                mgmt_args=(),
+                extra_args=("--blank",),
+            )
+        )
+
+    def test_matrix_case_count_after_dmvpn_blank_prune(self):
+        self.assertEqual(len(OFFLINE_FLAG_MATRIX), 2832)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds \	ests/test_cml2_terraform_plan.py\: generates each \CML2_OFFLINE_MATRIX\ case, runs \	erraform init\ + \plan\ with dummy creds (40/40 passed locally).
- Adds \scripts/validate-cml2-offline-matrix.py\ for the same gate from the shell (writes artifacts under \out/cml2-offline-matrix/\).
- Wires CI job \cml2-terraform-plan\ (path-filtered, opt-in marker \cml2_terraform\).

Live apply on CML (\dmvpn\ hub/spoke + EIGRP) was validated manually; this PR locks in the offline + plan half so regressions are caught before anyone touches a controller.

## Test plan
- [x] \TOPOGEN_CML2_TERRAFORM_PLAN=1 pytest tests/test_cml2_terraform_plan.py -m cml2_terraform\ (40 passed)
- [ ] CI \cml2-terraform-plan\ job green on PR


Made with [Cursor](https://cursor.com)