### PR TITLE
feat(TG-190): IPv6 SLAAC OOB mgmt sync and CP1 guardrails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.3.13
-Date Modified: 2026-06-09
+Doc Version: v1.3.14
+Date Modified: 2026-06-11
 
 - Called by: Users checking release notes, package managers, documentation generators
 - Reads from: Developer commits, PR descriptions, completed TODO items
@@ -20,6 +20,9 @@ Blast Radius: None (documentation only, but critical for communicating changes t
 This file lists changes. Format for Unreleased entries (files changed + rev): see [DEVELOPER.md Feature closeout checklist](DEVELOPER.md#feature-closeout-checklist).
 
 - Unreleased
+  - docs(developer): document `cml2/` vs `topogen --up` for NaC bootstrap at scale
+    - DEVELOPER.md adds a comparison table: prefer `cml2/` Terraform (`init` + `apply`, optional `plan`) for large labs and CI; use `topogen --up <yaml> [-i]` for quick one-off imports with no Terraform state. Notes mutual exclusion with `--terraform-cml2` at generation time.
+    - Files: DEVELOPER.md (rev v1.9.1 → v1.9.2), CHANGES.md (rev v1.3.13 → v1.3.14)
   - chore(docs): remove internal validation pipeline runbooks from public repo
     - Delete `docs/validation/TG-162-pipeline.md` and `docs/validation/TG-165-pipeline.md`; drop references from DEVELOPER.md, validation scripts, and `docs/nac/DMVPN-day0-nac-gap-audit.md`.
     - Files: DEVELOPER.md, scripts/validate-tg162-dmvpn-live.ps1, scripts/validate-tg165.ps1, docs/nac/DMVPN-day0-nac-gap-audit.md, CHANGES.md

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md - this file!):
-Doc Version: v1.9.0
-Date Modified: 2026-06-09
+Doc Version: v1.9.2
+Date Modified: 2026-06-11
 
 - Called by: Developers (new contributors, AI assistants), maintainers
 - Reads from: Codebase analysis, architecture decisions, team conventions
@@ -294,7 +294,7 @@ Pitfall:
 
 - `CHANGES.md`: what changed between released versions
 
-- `TODO.md`: in-progress ideas/roadmap (not guaranteed implemented)
+- `TODO.md`: optional maintainer notes (not guaranteed implemented); internal backlog is tracked in Jira (TG project on roberthosford.atlassian.net)
 
 
 
@@ -432,6 +432,8 @@ Implementation: `src/topogen/render.py` — `_render_bootstrap_config()`,
 calls). Provenance: `--bootstrap` is appended via `_append_common_offline_args_bits()`
 into lab `description`, hidden `notes`, and annotation `text_content`.
 
+**Import path:** at scale, use `cml2/` Terraform (see [Choosing CML import path](#choosing-cml-import-path-cml2-vs-topogen--up)); reserve `topogen --up` for small quick imports.
+
 **Live E2E (CSR1000v, mgmt-bridge):** generate with `--nac --bootstrap
 --terraform-cml2 --mgmt --mgmt-bridge`; `terraform apply` in `cml2/`; sync mgmt
 DHCP hosts (`scripts/sync-nac-mgmt-dhcp.py`, CML snooping fallback when local
@@ -529,6 +531,26 @@ Relationship to NaC:
 - `--terraform-cml2` and `--nac` are independent. When both are enabled, `cml2/` and `nac/` are sibling directories under the generated lab root.
 - Do not place CML lifecycle files under `nac/`; the `nac/` Terraform workspace targets device configuration through `netascode/nac-iosxe`.
 
+### Choosing CML import path (`cml2/` vs `topogen --up`)
+
+For **NaC bootstrap at scale**, prefer the generated `cml2/` workspace. Use
+`topogen --up` only for quick one-off manual imports (small labs, local iteration).
+
+| Path | Best for | CML state | Deploy |
+|------|----------|-----------|--------|
+| `cml2/` | Large labs (100+ nodes), CI/CD, repeatable IaC lifecycle; pairs with `nac/` | Terraform state under `out/<lab>/cml2/` | After `topogen ... --offline-yaml --terraform-cml2 [--nac --bootstrap]`: `terraform -chdir=out/<lab>/cml2 init` then `apply` (`plan` optional but recommended) |
+| `topogen --up <yaml>` | Fast manual import, no Terraform footprint | None (direct CML API import) | `topogen --up out/<lab>/<lab>.yaml [-i]` — shorthand for `--import-yaml --import --start`; add `-i`/`--insecure` when the lab controller uses a self-signed cert |
+
+**Terraform vs CLI:** `plan` is optional for both `cml2/` and `nac/` workspaces;
+`init` + `apply` are required on Terraform paths. TopoGen does not run Terraform for
+you.
+
+**Guardrails:** `--terraform-cml2` rejects import flags (`--up`, `--import`,
+`--import-yaml`) at generation time — generate the scaffold first, then
+`terraform apply` in `cml2/`. Do not substitute `topogen --up` for `cml2/apply`
+on large NaC bootstrap labs (e.g. TG-190 300-node flat); agents and operators
+should follow the `cml2/` + `nac/` sibling workflow documented above.
+
 Tests (run when touching CML2 lifecycle):
 
 | File | Purpose |
@@ -609,7 +631,7 @@ Nice to have:
 
 - `CHANGES.md` (release notes)
 
-- `TODO.md` (roadmap)
+- `TODO.md` (optional maintainer notes; Jira TG backlog)
 
 - `.github/workflows/` (CI)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.8.7
-Date Modified: 2026-06-09
+Doc Version: v1.8.8
+Date Modified: 2026-06-11
 
 - Called by: Users (primary entry point), package managers (PyPI), GitHub viewers
 - Reads from: None (documentation only)
@@ -50,7 +50,7 @@ controller, creating the lab, nodes and links on the fly.
 | CONTRIBUTING.md | Contributors | Branching, commits, PR conventions |
 | TESTED.md | CI/CD | Platform and dependency validation |
 | CHANGES.md | All | Release history |
-| TODO.md | Developers | Roadmap and planned work |
+| TODO.md | Maintainers | Optional maintainer notes; internal backlog tracked in Jira (TG project) |
 | PKI.md | Users, developers | PKI flags, CA-ROOT, EEM, auto-deploy certs, troubleshooting |
 | docs/nac/iosxe-one-router-golden-contract.md | Developers | Canonical one-router IOS-XE NaC contract (TG-116) |
 | docs/nac/topogen-to-nac-field-mapping.md | Developers | TopoGen-to-NaC field mapping matrix for adapter work |

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!--
 File Chain (see DEVELOPER.md):
-Doc Version: v1.6.50
-Date Modified: 2026-06-08
+Doc Version: v1.6.54
+Date Modified: 2026-06-11
 
 - Called by: Developers planning features, LLMs adding work items, project management
 - Reads from: Developer input, user requests, issue tracker
@@ -16,6 +16,8 @@ Blast Radius: Medium (guides development priorities but doesn't affect code exec
 -->
 
 # TODO
+
+**Maintainers:** Internal backlog and sprint planning live in Jira ([TG project](https://roberthosford.atlassian.net/jira/software/projects/TG)). This file is optional context for contributors and LLMs — not the source of truth for what ships next.
 
 This file tracks in-progress work and future ideas for TopoGen.
 
@@ -141,9 +143,15 @@ Recent completions:
 
 ## Future ideas
 
+### NaC / OOB
+
 - [ ] **NaC: `--nac` help text omits `nx`** — the `nodes` positional `--help` string lists `nodes=2 simple/flat/flat-pair` but omits `nx`, even though the standalone `--nac` help and `validate_nac_mvp_guardrails()` allow `nodes=2 --mode nx`. One-line fix in `src/topogen/main.py` argparse help; then refresh the README `--help` block. (Follow-up from TG-S13.)
 - [x] **NaC: Terraform plan deployability gate (TG-161)** — opt-in pytest (`tests/test_nac_terraform_plan.py`, `TOPOGEN_TERRAFORM_PLAN=1` / `-m terraform`) runs `terraform init` + `terraform plan` on a 9-case NaC matrix (includes DMVPN IKEv2-PSK); CI job `NaC Terraform plan contract` when NaC paths change. Supersedes the earlier `validate`-only idea (plan evaluates `nac.yaml` module locals).
 - [x] ~~**NaC: extend `--nac` to DMVPN**~~ Done for DMVPN flat and flat-pair offline paths in TG-151; deterministic `nac_router_nodes` feed the shared NaC writer.
+
+- [ ] **TG-191: Emit NaC mgmt sync helper with `--nac` scaffold** — ([TG-191](https://roberthosford.atlassian.net/browse/TG-191), under TG-189/TG-190) Emit `nac/sync-nac-mgmt.*` + `NAC-WORKFLOW.md` with `--nac` so bootstrap labs get a documented lab-up → sync → NaC apply path without hunting `scripts/`. Move IPv4 DHCP + IPv6 SLAAC sync into `src/topogen/nac_mgmt_sync.py`; optional `topogen sync-nac-mgmt` subcommand. Reference impl on branch `TG-190-oob-slaac-dhcpv6` (`scripts/nac_mgmt_sync_lib.py`, `scripts/sync-nac-mgmt-ipv6-slaac.py`, `scripts/sync-nac-mgmt-dhcp.py`).
+
+- [ ] **TG-192: CML CI/CD pipeline + per-ticket scoped CML users** — ([TG-192](https://roberthosford.atlassian.net/browse/TG-192), epic TG-189; blocked by TG-191) End-to-end Jira → generate → `cml2` deploy → `sync-nac-mgmt` → NaC apply → verify → MCP `create_cml_user` (lab_view+lab_exec, admin: false) → READY comment; teardown on Done. Phases: DEVELOPER.md runbook, GitHub Actions skeleton, Jira webhook, `provision-cml-user` subcommand. Reference lab: TG-190-flat-300-nac-v6 (`2be6f617-cf45-4bff-8970-2c9f28ac01d3`).
 
 - [ ] **TG-109: New feature: FlexVPN** — add FlexVPN (IKEv2-native) hub-and-spoke overlay support
   - FlexVPN is the IKEv2-native replacement for DMVPN (no GRE/NHRP, pure IKEv2 + IPsec with virtual-template and route injection via IKEv2 routing or BGP)
@@ -279,7 +287,6 @@ Recent completions:
 - [ ] Explore shareable, self-describing lab intents (example lab collection / "marketplace" concept)
 - [ ] Formalize serialized intent model (versioned `topogen:` schema embedded in lab YAML)
 - [ ] Support regenerating a lab from its embedded intent (`topogen regenerate lab.yaml`)
-- [ ] Make management plane a first-class intent (mgmt VRF, reserved interface, IPv4/IPv6 mode)
 - [ ] Emit machine-readable inventory alongside offline lab output
 - [ ] Add intent-level validation and least-astonishment checks before rendering
 - [ ] Support named intent profiles / presets for common lab patterns
@@ -298,10 +305,6 @@ Recent completions:
   - Complements: "Embed serialized intent in YAML" (above) — YAML embedding covers offline files; this covers live CML labs.
   - Blast radius: render.py (inject annotation on online lab creation), main.py (--regenerate reads annotation from CML API).
 
-- [ ] Management Plane as First-Class Citizen:
-  - Automate a dedicated `management-vrf` configuration for `GigabitEthernet0/0` across all routers.
-  - Implement a deterministic IP calculator to assign static IPv4 and IPv6 management addresses based on Node ID.
-
 - [ ] Automation Inventory Emission:
   - Generate an `inventory.json` (or `.yaml`/`.csv`) artifact during the offline generation phase.
   - Include node names, management IPs, VRF names, and platform types to enable instant tool ingestion (Ansible, Nornir, Netmiko).
@@ -313,14 +316,8 @@ Recent completions:
 - [ ] Gooey Round-Trip Integration:
   - Add logic to prepopulate Gooey GUI fields by parsing the serialized intent from an existing lab YAML.
 
-- [ ] Add dedicated management VRF on Gi0/0 with deterministic IPv4/IPv6 addressing (medium effort).
-  - Why: Enables isolated mgmt plane for hundreds of routers; deterministic IPs (e.g., 172.16.0.{n+10}/24) make it predictable and unlock programmatic config via tools like Ansible; tie to --enable-mgmt-vrf flag and wire to a mgmt_switch.
-
 - [ ] Embed serialized intent in YAML (`topogen:` block) for regeneration workflows (medium effort).
   - Why: Makes YAML the single source of truth with embedded params (mode, nodes, template, mgmt config); add `topogen regenerate lab.yaml` subcommand to unlock round-trip editing, GitOps, and easy tweaks without re-running full CLI.
-
-- [ ] Full DHCP + IPv6 on management plane (medium effort).
-  - Why: Layer DHCPv4/v6 via dnsmasq on DNS host with conditional templates for static vs. dynamic; pairs with mgmt VRF for "instant" auto-setup and dual-stack support in large labs.
 
 - [ ] Post-build automation hooks (low effort).
   - Why: Add --post-hook flag for running scripts after generation (e.g., start lab, poll readiness, or run Ansible from inventory); unlocks "one command to fully configured lab" workflows.

--- a/docs/TG-190-checkpoint-1.md
+++ b/docs/TG-190-checkpoint-1.md
@@ -1,0 +1,86 @@
+# TG-190 Checkpoint 1 — OOB IPv6 mgmt in VRF (offline render + CML config smoke)
+
+Epic: **TG-189** · Story: **TG-190** · Branch: `TG-190-oob-slaac-dhcpv6`
+
+## In scope (Checkpoint 1 ONLY)
+
+- **CLI:** `--mgmt-ipv6-mode {slaac,dhcpv6}` (requires `--mgmt` + `--mgmt-vrf`, not `global`; compatible with `--mgmt-bridge` for CP2 reachability)
+- **CLI:** optional `--mgmt-ipv6-cidr` (SLAAC prefix / DHCPv6 pool hint; carried in render context)
+- **`render.py`:** centralized `_build_mgmt_context()` with IPv6 fields
+- **Router templates** (`csr1000v.jinja2`, `iosv.jinja2`): OOB management interface gets IPv6 in mgmt VRF — SLAAC (`ipv6 address autoconfig`) or DHCPv6 client (`ipv6 address dhcp`); CSR adds `address-family ipv6` under vrf definition when IPv6 mgmt is enabled
+- **Unit tests:** offline render asserts expected lines on OOB Gi; CLI guardrail tests in `tests/test_nac_cli_guardrails.py` and `tests/test_mgmt_ipv6_vrf.py`
+- **CML config smoke (CP1):** lab boots; OOB interface shows expected IPv6 mgmt lines in running-config and `show ipv6 interface` (no global SLAAC address required yet)
+
+## Scale: IPv6-only OOB for large labs
+
+Labs with **16 or more routers** and `--mgmt` **must** set `--mgmt-ipv6-mode` (`slaac` or `dhcpv6`) with a named `--mgmt-vrf`. The default IPv4 OOB path (`ip address dhcp` on Gi0/5 / Gi5, or static addresses carved from `--mgmt-cidr`) assigns one IPv4 lease or host per router on the shared management bridge; at 300-node scale this exhausts the bridge DHCP pool and can crash or destabilize the entire lab network. Use `--mgmt-ipv6-mode slaac --mgmt-bridge` (and optional `--mgmt-ipv6-cidr`) for IPv6-only OOB with no IPv4 on the management interface.
+
+## External management bridge (CML — CP2 / address acquisition)
+
+`--mgmt-bridge` bridges `SWoob0` to the CML host via `ext-conn-mgmt` so external RA/DHCPv6 can reach OOB interfaces. **CP1 config smoke** does not require a global SLAAC address; bridge + RA source are needed for live address acquisition (CP2).
+
+## Explicitly OUT of Checkpoint 1
+
+- dnsmasq DHCPv6 server on DNS host (TG-87 / CP2)
+- NaC inventory `ansible_host` IPv6 (TG-83 / CP3)
+- Dual-stack IPv4+IPv6 on the same OOB interface
+- **SLAAC global address acquisition** on OOB (needs RA/dnsmasq or external prefix — CP2)
+- Full topology-mode regression matrix (see follow-up below)
+
+## Checkpoint 1 DONE when
+
+```bash
+pytest tests/test_mgmt_ipv6_vrf.py tests/test_nac_cli_guardrails.py -q
+```
+
+passes, and offline render with:
+
+```bash
+topogen 2 --mode simple --offline-yaml out.yaml --mgmt --mgmt-vrf Mgmt-vrf --mgmt-ipv6-mode slaac -T csr1000v
+```
+
+shows IPv6 on `GigabitEthernet5` (CSR) or `GigabitEthernet0/5` (IOSv), vrf IPv6 address-family (CSR), and **no regression** on the default IPv4 `--mgmt` path (`ip address dhcp`).
+
+## CML config smoke (initial validation — flat mode first)
+
+Initial live CML validation uses **flat** mode (not simple). A full mode matrix is follow-up work after flat passes.
+
+Set controller credentials in the shell (`VIRL2_*`; `-i` if the controller uses a self-signed cert):
+
+```bash
+# PowerShell
+$env:VIRL2_URL = "https://192.168.1.183"
+$env:VIRL2_USER = "admin"
+$env:VIRL2_PASS = "<secret>"
+
+topogen --cml-version 0.3.1 -L "TG-190-SLAAC-CP1-flat" `
+  -m flat -T iosv --device-template iosv `
+  --mgmt --mgmt-vrf Mgmt-vrf --mgmt-ipv6-mode slaac `
+  --mgmt-ipv6-cidr fd00:10:254::/64 `
+  -i 4
+```
+
+Use a **new lab title** with a `-flat` suffix if an earlier `TG-190-SLAAC-CP1` simple-mode lab already exists.
+
+After boot, set pyATS creds on IOSv routers (`cisco` / `cisco` / enable `cisco`), then on **R1** (CML MCP `send_cli_command`):
+
+- `show run int Gi0/5` — expect `vrf forwarding Mgmt-vrf`, `ipv6 enable`, `ipv6 address autoconfig`
+- `show ipv6 interface GigabitEthernet0/5` — up/up; `VPN Routing/Forwarding "Mgmt-vrf"`; link-local present; `Stateless address autoconfig enabled`
+- `show ipv6 interface brief` — Gi0/5 up with link-local (IOSv does not accept `show ipv6 interface vrf <name>`)
+
+**CP1 pass criteria:** config smoke only (correct lines on OOB Gi in VRF). **CP1 does not require** a global SLAAC address on the OOB interface.
+
+## Follow-up: full topology mode test matrix (not CP1)
+
+Run after flat CP1 smoke passes. Same IPv6 mgmt flags; vary `-m` / node count as appropriate:
+
+| Mode | Notes |
+|------|--------|
+| `simple` | Minimal 2-router smoke (offline + CML) |
+| `flat` | **First** live CML target (4 routers) |
+| `flat-pair` | Odd/even pair links + OOB |
+| `nx` | NX-style layout |
+| `dmvpn` + `--mgmt` | Overlay + OOB (flat underlay default) |
+| `dmvpn` + `--dmvpn-underlay flat-pair` + `--mgmt` | DMVPN on flat-pair underlay |
+
+CSR1000v variants mirror IOSv where templates differ (`GigabitEthernet5` vs `GigabitEthernet0/5`).

--- a/scripts/nac_mgmt_sync_lib.py
+++ b/scripts/nac_mgmt_sync_lib.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Shared NaC mgmt host sync helpers for DHCP (IPv4) and SLAAC (IPv6) scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROUTER_NODE_DEFINITIONS = frozenset({"csr1000v", "iosv"})
+
+
+def mgmt_interface_name(node_definition: str, mgmt_slot: int) -> str:
+    if node_definition == "iosv":
+        return f"GigabitEthernet0/{mgmt_slot}"
+    return f"GigabitEthernet{mgmt_slot}"
+
+
+def canonical_name(index: int) -> str:
+    return f"iosv-{index:02d}"
+
+
+def load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def dump_yaml(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def patch_nac_files(nac_root: Path, mapping: dict[str, str]) -> None:
+    nac_yaml = nac_root / "nac.yaml"
+    inventory_yaml = nac_root / "inventory.yaml"
+    devices_yaml = nac_root / "devices.yaml"
+
+    nac_data = load_yaml(nac_yaml)
+    for device in nac_data.get("iosxe", {}).get("devices", []):
+        name = device.get("name", "")
+        if name in mapping:
+            device["host"] = mapping[name]
+    dump_yaml(nac_yaml, nac_data)
+
+    inv_data = load_yaml(inventory_yaml)
+    host_groups: list[dict] = []
+    all_block = inv_data.get("all", {})
+    if isinstance(all_block.get("hosts"), dict):
+        host_groups.append(all_block["hosts"])
+    for group in all_block.get("children", {}).values():
+        if isinstance(group, dict) and isinstance(group.get("hosts"), dict):
+            host_groups.append(group["hosts"])
+    for hosts in host_groups:
+        for host_name, host_vars in hosts.items():
+            if host_name in mapping and isinstance(host_vars, dict):
+                host_vars["ansible_host"] = mapping[host_name]
+    dump_yaml(inventory_yaml, inv_data)
+
+    dev_data = load_yaml(devices_yaml)
+    for device in dev_data.get("devices", []):
+        name = device.get("name", "")
+        if name in mapping:
+            device["mgmt_ip"] = mapping[name]
+    dump_yaml(devices_yaml, dev_data)

--- a/scripts/ssh-fanout.py
+++ b/scripts/ssh-fanout.py
@@ -1,0 +1,268 @@
+﻿#!/usr/bin/env python3
+"""Parallel SSH fan-out to IOSv routers listed in router-hosts.csv."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import paramiko
+
+# Legacy IOSv SSH (match OpenSSH: -o KexAlgorithms=... -o HostKeyAlgorithms=ssh-rsa)
+LEGACY_DISABLED_ALGORITHMS: dict[str, list[str]] = {
+    "pubkeys": ["rsa-sha2-512", "rsa-sha2-256"],
+    "keys": ["rsa-sha2-512", "rsa-sha2-256"],
+}
+
+DEFAULT_HOSTS = Path(__file__).resolve().parent / "router-hosts.csv"
+UPTIME_CMD = "show version | include uptime"
+UPTIME_RE = re.compile(r"uptime is (.+)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class RouterHost:
+    label: str
+    ipv6_mgmt: str
+    user: str
+    password: str
+    canonical: str = ""
+    hostname: str = ""
+
+
+def load_hosts(path: Path, labels: Iterable[str] | None = None) -> list[RouterHost]:
+    wanted = {x.strip() for x in labels} if labels else None
+    hosts: list[RouterHost] = []
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            label = (row.get("label") or "").strip()
+            if not label:
+                continue
+            if wanted is not None and label not in wanted:
+                continue
+            ipv6 = (row.get("ipv6_mgmt") or row.get("ipv6") or "").strip()
+            if not ipv6:
+                continue
+            hosts.append(
+                RouterHost(
+                    label=label,
+                    ipv6_mgmt=ipv6,
+                    user=(row.get("user") or "cisco").strip(),
+                    password=(row.get("password") or "cisco").strip(),
+                    canonical=(row.get("canonical") or "").strip(),
+                    hostname=(row.get("hostname") or label).strip(),
+                )
+            )
+    return hosts
+
+
+def run_ssh_command(host: RouterHost, command: str, timeout: float) -> tuple[str, str, str]:
+    """Returns (label, status, output) where status is ok|fail."""
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(
+            hostname=host.ipv6_mgmt,
+            port=22,
+            username=host.user,
+            password=host.password,
+            timeout=timeout,
+            banner_timeout=timeout,
+            auth_timeout=timeout,
+            allow_agent=False,
+            look_for_keys=False,
+            disabled_algorithms=LEGACY_DISABLED_ALGORITHMS,
+        )
+        _stdin, stdout, stderr = client.exec_command(command, timeout=timeout)
+        out = stdout.read().decode("utf-8", errors="replace")
+        err = stderr.read().decode("utf-8", errors="replace")
+        combined = (out + err).strip()
+        if stdout.channel.recv_exit_status() != 0 and not combined:
+            return host.label, "fail", err.strip() or "non-zero exit"
+        return host.label, "ok", combined
+    except Exception as exc:  # noqa: BLE001 — per-host errors collected in batch
+        return host.label, "fail", str(exc)
+    finally:
+        client.close()
+
+
+def parse_uptime(text: str) -> str:
+    for line in text.splitlines():
+        m = UPTIME_RE.search(line)
+        if m:
+            return m.group(1).strip()
+    one_line = " ".join(text.split())
+    m = UPTIME_RE.search(one_line)
+    if m:
+        return m.group(1).strip()
+    return one_line[:500] if one_line else ""
+
+
+def fanout(
+    hosts: list[RouterHost],
+    command: str,
+    workers: int,
+    timeout: float,
+) -> list[dict[str, str]]:
+    by_label = {h.label: h for h in hosts}
+    results: dict[str, dict[str, str]] = {}
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(run_ssh_command, h, command, timeout): h.label for h in hosts
+        }
+        for fut in as_completed(futures):
+            label = futures[fut]
+            h = by_label[label]
+            lbl, status, output = fut.result()
+            results[lbl] = {
+                "label": lbl,
+                "ipv6_mgmt": h.ipv6_mgmt,
+                "status": status,
+                "output": output,
+            }
+
+    return [results[h.label] for h in hosts if h.label in results]
+
+
+def write_uptime_artifacts(base: Path, rows: list[dict[str, str]]) -> None:
+    csv_path = base / "router-uptime.csv"
+    md_path = base / "ROUTER-UPTIME.md"
+    ok = sum(1 for r in rows if r["status"] == "ok")
+    fail = len(rows) - ok
+
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["label", "ipv6_mgmt", "status", "uptime", "raw_or_error"])
+        for r in rows:
+            uptime = parse_uptime(r["output"]) if r["status"] == "ok" else ""
+            raw = r["output"] if r["status"] != "ok" else r["output"]
+            w.writerow([r["label"], r["ipv6_mgmt"], r["status"], uptime, raw])
+
+    lines = [
+        "# Router uptime (batch SSH)",
+        "",
+        f"- **Total:** {len(rows)}",
+        f"- **OK:** {ok}",
+        f"- **Failed:** {fail}",
+        "",
+        "| Router | Status | Uptime / error |",
+        "|--------|--------|----------------|",
+    ]
+    for r in rows:
+        if r["status"] == "ok":
+            cell = parse_uptime(r["output"]) or r["output"].replace("|", "\\|")[:120]
+        else:
+            cell = r["output"].replace("|", "\\|").replace("\n", " ")[:120]
+        lines.append(f"| {r['label']} | {r['status']} | {cell} |")
+
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Wrote {csv_path}")
+    print(f"Wrote {md_path}")
+    print(f"Summary: {ok} ok, {fail} failed, {len(rows)} total")
+
+
+def openssh_sample_command(host: RouterHost) -> str:
+    bracket = f"[{host.ipv6_mgmt}]"
+    opts = (
+        "-6 -o KexAlgorithms=diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1 "
+        "-o HostKeyAlgorithms=ssh-rsa -o PubkeyAcceptedAlgorithms=ssh-rsa "
+        "-o StrictHostKeyChecking=no"
+    )
+    return f"ssh {opts} {host.user}@{bracket}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a CLI command on many IOSv routers via parallel SSH (Paramiko)."
+    )
+    parser.add_argument(
+        "--hosts",
+        type=Path,
+        default=DEFAULT_HOSTS,
+        help=f"CSV path (default: {DEFAULT_HOSTS.name})",
+    )
+    parser.add_argument(
+        "--command",
+ "-c",
+        default="",
+        help="IOS command to run (required unless --uptime)",
+    )
+    parser.add_argument(
+        "--uptime",
+        action="store_true",
+        help=f"Collect uptime via: {UPTIME_CMD}",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=25,
+        help="Parallel SSH sessions (default: 25)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=45.0,
+        help="Connect/command timeout seconds (default: 45)",
+    )
+    parser.add_argument(
+        "--only",
+        nargs="*",
+        help="Limit to router labels (e.g. R1 R2)",
+    )
+    parser.add_argument(
+        "--print-openssh",
+        metavar="LABEL",
+        help="Print OpenSSH command for one router (interactive use)",
+    )
+    args = parser.parse_args()
+
+    if not args.hosts.is_file():
+        print(f"Hosts file not found: {args.hosts}", file=sys.stderr)
+        return 1
+
+    hosts = load_hosts(args.hosts, args.only)
+    if not hosts:
+        print("No hosts loaded.", file=sys.stderr)
+        return 1
+
+    if args.print_openssh:
+        match = [h for h in hosts if h.label == args.print_openssh]
+        if not match:
+            all_h = load_hosts(args.hosts)
+            match = [h for h in all_h if h.label == args.print_openssh]
+        if not match:
+            print(f"Unknown label: {args.print_openssh}", file=sys.stderr)
+            return 1
+        print(openssh_sample_command(match[0]))
+        return 0
+
+    command = UPTIME_CMD if args.uptime else args.command.strip()
+    if not command:
+        parser.error("Provide --command or use --uptime")
+
+    t0 = time.perf_counter()
+    rows = fanout(hosts, command, args.workers, args.timeout)
+    elapsed = time.perf_counter() - t0
+    print(f"Finished {len(rows)} hosts in {elapsed:.1f}s")
+
+    if args.uptime:
+        write_uptime_artifacts(args.hosts.parent, rows)
+    else:
+        for r in rows:
+            print(f"\n=== {r['label']} ({r['ipv6_mgmt']}) [{r['status']}] ===")
+            print(r["output"])
+
+    fails = [r for r in rows if r["status"] != "ok"]
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync-nac-mgmt-dhcp.py
+++ b/scripts/sync-nac-mgmt-dhcp.py
@@ -11,23 +11,24 @@ import sys
 from ipaddress import ip_address
 from pathlib import Path
 
-import yaml
-
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
+SCRIPTS = ROOT / "scripts"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from nac_mgmt_sync_lib import (  # noqa: E402
+    ROUTER_NODE_DEFINITIONS,
+    canonical_name as _canonical_name,
+    mgmt_interface_name as _mgmt_interface_name,
+    patch_nac_files as _patch_nac_files,
+)
 
 MGMT_IFACE_FILTER = "GigabitEthernet5"
 BRIDGE_PREFIX = "192.168.1."
-ROUTER_NODE_DEFINITIONS = frozenset({"csr1000v", "iosv"})
 IP_RE = re.compile(r"\b(\d{1,3}(?:\.\d{1,3}){3})\b")
-
-
-def _mgmt_interface_name(node_definition: str, mgmt_slot: int) -> str:
-    if node_definition == "iosv":
-        return f"GigabitEthernet0/{mgmt_slot}"
-    return f"GigabitEthernet{mgmt_slot}"
 
 
 def _dhcp_fix_commands(iface_name: str) -> str:
@@ -87,52 +88,6 @@ def _parse_mgmt_ip(output: str, iface_filter: str) -> str | None:
         if str(ip).startswith(BRIDGE_PREFIX):
             return str(ip)
     return None
-
-
-def _canonical_name(index: int) -> str:
-    return f"iosv-{index:02d}"
-
-
-def _load_yaml(path: Path) -> dict:
-    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-
-
-def _dump_yaml(path: Path, data: dict) -> None:
-    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
-
-
-def _patch_nac_files(nac_root: Path, mapping: dict[str, str]) -> None:
-    nac_yaml = nac_root / "nac.yaml"
-    inventory_yaml = nac_root / "inventory.yaml"
-    devices_yaml = nac_root / "devices.yaml"
-
-    nac_data = _load_yaml(nac_yaml)
-    for device in nac_data.get("iosxe", {}).get("devices", []):
-        name = device.get("name", "")
-        if name in mapping:
-            device["host"] = mapping[name]
-    _dump_yaml(nac_yaml, nac_data)
-
-    inv_data = _load_yaml(inventory_yaml)
-    host_groups: list[dict] = []
-    all_block = inv_data.get("all", {})
-    if isinstance(all_block.get("hosts"), dict):
-        host_groups.append(all_block["hosts"])
-    for group in all_block.get("children", {}).values():
-        if isinstance(group, dict) and isinstance(group.get("hosts"), dict):
-            host_groups.append(group["hosts"])
-    for hosts in host_groups:
-        for host_name, host_vars in hosts.items():
-            if host_name in mapping and isinstance(host_vars, dict):
-                host_vars["ansible_host"] = mapping[host_name]
-    _dump_yaml(inventory_yaml, inv_data)
-
-    dev_data = _load_yaml(devices_yaml)
-    for device in dev_data.get("devices", []):
-        name = device.get("name", "")
-        if name in mapping:
-            device["mgmt_ip"] = mapping[name]
-    _dump_yaml(devices_yaml, dev_data)
 
 
 def main() -> int:

--- a/scripts/sync-nac-mgmt-ipv6-slaac.py
+++ b/scripts/sync-nac-mgmt-ipv6-slaac.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Sync NaC mgmt hosts from live CML pyATS IPv6 SLAAC addresses on OOB Gi."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from ipaddress import IPv6Address, ip_address
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from nac_mgmt_sync_lib import (  # noqa: E402
+    ROUTER_NODE_DEFINITIONS,
+    canonical_name,
+    mgmt_interface_name,
+    patch_nac_files,
+)
+
+IPV6_CANDIDATE_RE = re.compile(
+    r"(?<![0-9A-Fa-f:])(?:"
+    r"(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|"
+    r"(?:[0-9A-Fa-f]{1,4}:){1,7}:|"
+    r":(?::[0-9A-Fa-f]{1,4}){1,7}|"
+    r"(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|"
+    r"(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}|"
+    r"(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}|"
+    r"(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}|"
+    r"(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}|"
+    r"[0-9A-Fa-f]{1,4}:(?::[0-9A-Fa-f]{1,4}){1,6}|"
+    r":(?::[0-9A-Fa-f]{1,4}){1,7}|"
+    r"fe80::[0-9A-Fa-f:]+|"
+    r"FE80::[0-9A-Fa-f:]+"
+    r")(?![0-9A-Fa-f:])",
+    re.IGNORECASE,
+)
+
+DEFAULT_PYATS_CREDS = {
+    "username": "cisco",
+    "password": "cisco",
+    "enable_password": "cisco",
+}
+
+
+def _is_global_unicast(ip: IPv6Address) -> bool:
+    return (
+        not ip.is_link_local
+        and not ip.is_loopback
+        and not ip.is_multicast
+        and not ip.is_unspecified
+    )
+
+
+def _normalize_ipv6(raw: str) -> str | None:
+    candidate = raw.strip().strip("[]").split("/")[0].split("%")[0]
+    try:
+        ip = ip_address(candidate)
+    except ValueError:
+        return None
+    if ip.version != 6:
+        return None
+    return str(ip)
+
+
+def _extract_ipv6_candidates(text: str) -> list[str]:
+    found: list[str] = []
+    for match in IPV6_CANDIDATE_RE.finditer(text):
+        normalized = _normalize_ipv6(match.group(0))
+        if normalized and normalized not in found:
+            found.append(normalized)
+    return found
+
+
+def pick_preferred_global(addresses: list[str]) -> str | None:
+    globals_: list[str] = []
+    for addr in addresses:
+        ip = ip_address(addr)
+        if isinstance(ip, IPv6Address) and _is_global_unicast(ip):
+            globals_.append(addr)
+    if not globals_:
+        return None
+    for prefix in ("2600:", "fd00:"):
+        for addr in globals_:
+            if addr.lower().startswith(prefix):
+                return addr
+    return globals_[0]
+
+
+def _iface_section(output: str, iface_name: str) -> str:
+    lines = output.splitlines()
+    section: list[str] = []
+    in_section = False
+    for line in lines:
+        stripped = line.strip()
+        if not in_section:
+            if iface_name in line and (
+                stripped.startswith("GigabitEthernet") or stripped.startswith("Gi")
+            ):
+                in_section = True
+                section = [line]
+            continue
+        if stripped.startswith("GigabitEthernet") and iface_name not in line:
+            break
+        if stripped.startswith("Gi") and iface_name not in line and "Ethernet" not in iface_name:
+            break
+        section.append(line)
+    return "\n".join(section)
+
+
+def parse_mgmt_ipv6(output: str, iface_name: str) -> str | None:
+    """Parse global SLAAC IPv6 for iface from show ipv6 interface* output."""
+    section = _iface_section(output, iface_name)
+    if not section:
+        for line in output.splitlines():
+            if iface_name not in line:
+                continue
+            if "unassigned" in line.lower():
+                continue
+            addrs = _extract_ipv6_candidates(line)
+            picked = pick_preferred_global(addrs)
+            if picked:
+                return picked
+        return None
+    addrs = _extract_ipv6_candidates(section)
+    return pick_preferred_global(addrs)
+
+
+def mgmt_ipv6_from_cml_interface(node, iface_name: str) -> str | None:
+    """Read mgmt SLAAC IPv6 from CML L3 address snooping (no local pyATS required)."""
+    for iface in node.interfaces():
+        if iface.label != iface_name:
+            continue
+        candidates: list[str] = []
+        for source in (
+            getattr(iface, "discovered_ipv6", None),
+            (getattr(iface, "ip_snooped_info", None) or {}).get("ipv6"),
+        ):
+            if not source:
+                continue
+            if isinstance(source, str):
+                candidates.append(source)
+            else:
+                candidates.extend(str(item) for item in source)
+        normalized: list[str] = []
+        for candidate in candidates:
+            normalized_addr = _normalize_ipv6(str(candidate))
+            if normalized_addr:
+                normalized.append(normalized_addr)
+        return pick_preferred_global(normalized)
+    return None
+
+
+def _set_pyats_creds(node, creds: dict[str, str]) -> None:
+    node.update({"pyats": creds}, exclude_configurations=True)
+
+
+def _collect_router_nodes(lab):
+    routers = []
+    for node in lab.nodes():
+        if node.node_definition not in ROUTER_NODE_DEFINITIONS:
+            continue
+        label = node.label
+        if not label.startswith("R") or not label[1:].isdigit():
+            continue
+        routers.append((int(label[1:]), node))
+    routers.sort(key=lambda item: item[0])
+    return routers
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lab-id", help="CML lab UUID (required unless --mapping-file)")
+    parser.add_argument("--nac-root", required=True, type=Path, help="Path to nac/ output tree")
+    parser.add_argument(
+        "--mapping-file",
+        type=Path,
+        help="JSON map of iosv-NN -> IPv6 (skip CML polling)",
+    )
+    parser.add_argument(
+        "--set-pyats-creds",
+        action="store_true",
+        help="Set cisco/cisco pyATS credentials on BOOTED routers before polling",
+    )
+    parser.add_argument(
+        "--cml-snoop-only",
+        action="store_true",
+        help="Use CML L3 address snooping only (no local pyATS); default tries pyATS first",
+    )
+    parser.add_argument(
+        "--mgmt-slot",
+        type=int,
+        default=5,
+        help="Mgmt interface slot (default 5 -> Gi0/5 on IOSv)",
+    )
+    parser.add_argument(
+        "--device-template",
+        choices=("iosv", "csr1000v"),
+        default="iosv",
+        help="Router image family for mgmt interface naming (default iosv)",
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=25,
+        help="Print progress every N routers (0 disables)",
+    )
+    args = parser.parse_args()
+
+    if args.mapping_file:
+        mapping = json.loads(args.mapping_file.read_text(encoding="utf-8"))
+        patch_nac_files(args.nac_root, mapping)
+        report_path = args.nac_root / "mgmt_ipv6_sync.json"
+        report_path.write_text(
+            json.dumps({"synced": len(mapping), "mapping": mapping}, indent=2),
+            encoding="utf-8",
+        )
+        print(json.dumps({"synced": len(mapping), "report": str(report_path)}, indent=2))
+        return 0
+
+    if not args.lab_id:
+        print("--lab-id is required unless --mapping-file is provided", file=sys.stderr)
+        return 1
+
+    try:
+        from virl2_client import ClientLibrary
+    except ImportError:
+        print("virl2_client is required", file=sys.stderr)
+        return 1
+
+    url = os.environ.get("VIRL2_URL", "https://192.168.1.183")
+    user = os.environ.get("VIRL2_USER", "")
+    password = os.environ.get("VIRL2_PASS", "")
+    client = ClientLibrary(url, user, password, ssl_verify=False)
+    lab = client.join_existing_lab(args.lab_id)
+    lab.sync_l3_addresses_if_outdated()
+
+    iface_name = mgmt_interface_name(args.device_template, args.mgmt_slot)
+    mapping: dict[str, str] = {}
+    report: dict[str, object] = {
+        "lab_id": args.lab_id,
+        "nac_root": str(args.nac_root),
+        "mgmt_interface": iface_name,
+        "routers": {},
+    }
+
+    routers = _collect_router_nodes(lab)
+    total = len(routers)
+    processed = 0
+
+    for index, node in routers:
+        label = node.label
+        canonical = canonical_name(index)
+        entry: dict[str, str | None] = {
+            "state": str(node.state),
+            "mgmt_ipv6": None,
+            "source": None,
+            "error": None,
+        }
+
+        if str(node.state) != "BOOTED":
+            report["routers"][label] = entry
+            processed += 1
+            continue
+
+        mgmt_ipv6: str | None = None
+        if not args.cml_snoop_only:
+            try:
+                if args.set_pyats_creds:
+                    _set_pyats_creds(node, DEFAULT_PYATS_CREDS)
+
+                brief_cmd = "show ipv6 interface brief"
+                brief_out = str(node.run_pyats_command(brief_cmd, config=False))
+                mgmt_ipv6 = parse_mgmt_ipv6(brief_out, iface_name)
+                if mgmt_ipv6:
+                    entry["source"] = "pyats_brief"
+                else:
+                    detail_cmd = f"show ipv6 interface {iface_name}"
+                    detail_out = str(node.run_pyats_command(detail_cmd, config=False))
+                    mgmt_ipv6 = parse_mgmt_ipv6(detail_out, iface_name)
+                    if mgmt_ipv6:
+                        entry["source"] = "pyats_detail"
+            except Exception as exc:  # noqa: BLE001 - surface per-node CML/pyATS failures
+                entry["error"] = str(exc) or type(exc).__name__
+
+        if not mgmt_ipv6:
+            mgmt_ipv6 = mgmt_ipv6_from_cml_interface(node, iface_name)
+            if mgmt_ipv6:
+                entry["source"] = "cml_snooped"
+                entry["error"] = None
+
+        entry["mgmt_ipv6"] = mgmt_ipv6
+        if mgmt_ipv6:
+            mapping[canonical] = mgmt_ipv6
+        report["routers"][label] = entry
+
+        processed += 1
+        if args.progress_every and processed % args.progress_every == 0:
+            print(
+                f"progress: {processed}/{total} routers polled, {len(mapping)} IPv6 synced",
+                file=sys.stderr,
+            )
+
+    if mapping:
+        patch_nac_files(args.nac_root, mapping)
+
+    report["synced"] = len(mapping)
+    report["total_routers"] = total
+    report_path = args.nac_root / "mgmt_ipv6_sync.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({"synced": len(mapping), "total": total, "report": str(report_path)}, indent=2))
+    return 0 if mapping else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/topogen/main.py
+++ b/src/topogen/main.py
@@ -131,6 +131,53 @@ def validate_bootstrap_guardrails(args, parser):
         parser.error("--bootstrap cannot be combined with --getvpn")
 
 
+# IPv4 OOB (DHCP or static from --mgmt-cidr) exhausts shared mgmt bridge pools above this.
+MGMT_IPV4_OOB_NODE_LIMIT = 16
+
+
+def validate_mgmt_ipv6_guardrails(args, parser):
+    """Fail-fast guardrails for OOB IPv6 management (TG-190 checkpoint 1)."""
+    ipv6_mode = getattr(args, "mgmt_ipv6_mode", None)
+    node_count = int(getattr(args, "nodes", 0) or 0)
+    if (
+        not ipv6_mode
+        and getattr(args, "enable_mgmt", False)
+        and node_count >= MGMT_IPV4_OOB_NODE_LIMIT
+    ):
+        parser.error(
+            f"With --mgmt and {node_count} nodes, IPv4 OOB (ip address dhcp or static "
+            f"addresses from --mgmt-cidr) exhausts the shared management bridge and can "
+            f"destabilize the lab. Use --mgmt-ipv6-mode slaac or dhcpv6 with a named "
+            f"--mgmt-vrf (and --mgmt-bridge for external RA/DHCPv6) for IPv6-only OOB "
+            f"at scale."
+        )
+    if not ipv6_mode:
+        if getattr(args, "mgmt_ipv6_cidr", None):
+            from ipaddress import IPv6Network
+
+            try:
+                IPv6Network(args.mgmt_ipv6_cidr, strict=False)
+            except ValueError as exc:
+                parser.error(f"Invalid --mgmt-ipv6-cidr: {exc}")
+        return
+    if not getattr(args, "enable_mgmt", False):
+        parser.error("--mgmt-ipv6-mode requires --mgmt")
+    mgmt_vrf = getattr(args, "mgmt_vrf", None)
+    if mgmt_vrf and str(mgmt_vrf).lower() == "global":
+        mgmt_vrf = None
+    if not mgmt_vrf:
+        parser.error(
+            "--mgmt-ipv6-mode requires a named --mgmt-vrf (not global routing table)"
+        )
+    if getattr(args, "mgmt_ipv6_cidr", None):
+        from ipaddress import IPv6Network
+
+        try:
+            IPv6Network(args.mgmt_ipv6_cidr, strict=False)
+        except ValueError as exc:
+            parser.error(f"Invalid --mgmt-ipv6-cidr: {exc}")
+
+
 def validate_cml2_lifecycle_guardrails(args, parser):
     """Fail-fast guardrails for CML2 Terraform lifecycle scaffold generation."""
     if not getattr(args, "terraform_cml2", False):
@@ -506,6 +553,21 @@ def create_argparser(parser_class=argparse.ArgumentParser):
         action="store_true",
         default=False,
         help="Add external-connector to bridge OOB management network to external network (requires --mgmt)",
+    )
+    parser.add_argument(
+        "--mgmt-ipv6-mode",
+        dest="mgmt_ipv6_mode",
+        type=str,
+        choices=("slaac", "dhcpv6"),
+        default=None,
+        help="OOB management IPv6 mode in mgmt VRF: slaac (autoconfig) or dhcpv6 (requires --mgmt and named --mgmt-vrf)",
+    )
+    parser.add_argument(
+        "--mgmt-ipv6-cidr",
+        dest="mgmt_ipv6_cidr",
+        type=str,
+        default=None,
+        help="Optional IPv6 prefix hint for SLAAC/DHCPv6 pool (e.g. fd00:10:254::/64)",
     )
     parser.add_argument(
         "--ntp",
@@ -974,6 +1036,7 @@ def main():
         # Validate mgmt-bridge requires mgmt
         if getattr(args, "mgmt_bridge", False) and not getattr(args, "enable_mgmt", False):
             parser.error("--mgmt-bridge requires --mgmt to be enabled")
+        validate_mgmt_ipv6_guardrails(args, parser)
         # Validate NTP flags
         if getattr(args, "ntp_server", None):
             from ipaddress import IPv4Address

--- a/src/topogen/render.py
+++ b/src/topogen/render.py
@@ -328,6 +328,10 @@ def _build_intent_description(args: Namespace, *, context: str) -> str:
             args_bits.append(f"--mgmt-vrf {args.mgmt_vrf}")
         if getattr(args, "mgmt_bridge", False):
             args_bits.append("--mgmt-bridge")
+        if getattr(args, "mgmt_ipv6_mode", None):
+            args_bits.append(f"--mgmt-ipv6-mode {args.mgmt_ipv6_mode}")
+        if getattr(args, "mgmt_ipv6_cidr", None):
+            args_bits.append(f"--mgmt-ipv6-cidr {args.mgmt_ipv6_cidr}")
     if getattr(args, "ntp_server", None):
         args_bits.append(f"--ntp {args.ntp_server}")
         if getattr(args, "ntp_vrf", None):
@@ -355,6 +359,26 @@ def _build_intent_description(args: Namespace, *, context: str) -> str:
     if getattr(args, "remark", None):
         desc += f" | remark: {args.remark}"
     return desc
+
+
+def _build_mgmt_context(args: object, *, mgmt_slot: int | None = None) -> dict[str, Any] | None:
+    """Build Jinja mgmt context dict for OOB management (IPv4 DHCP or IPv6 SLAAC/DHCPv6)."""
+    if not getattr(args, "enable_mgmt", False):
+        return None
+    slot = mgmt_slot if mgmt_slot is not None else int(getattr(args, "mgmt_slot", 5))
+    ctx: dict[str, Any] = {
+        "enabled": True,
+        "slot": slot,
+        "vrf": getattr(args, "mgmt_vrf", None),
+        "gw": getattr(args, "mgmt_gw", None),
+    }
+    ipv6_mode = getattr(args, "mgmt_ipv6_mode", None)
+    if ipv6_mode:
+        ctx["ipv6_mode"] = ipv6_mode
+        ipv6_cidr = getattr(args, "mgmt_ipv6_cidr", None)
+        if ipv6_cidr:
+            ctx["ipv6_cidr"] = ipv6_cidr
+    return ctx
 
 
 def _append_common_offline_args_bits(args_bits: list[str], args: object) -> None:
@@ -433,14 +457,7 @@ def _emit_offline_ca_root_mgmt_node(
             )
         ],
     )
-    ca_mgmt_ctx = None
-    if enable_mgmt:
-        ca_mgmt_ctx = {
-            "enabled": True,
-            "slot": mgmt_slot,
-            "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-            "gw": getattr(args, "mgmt_gw", None),
-        }
+    ca_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
     ca_ntp_ctx = None
     if getattr(args, "ntp_server", None):
         ca_ntp_ctx = {"server": args.ntp_server, "vrf": getattr(args, "ntp_vrf", None)}
@@ -740,16 +757,27 @@ def _render_bootstrap_config(cfg: Config, node: TopogenNode, args: Namespace) ->
         "!",
     ]
 
+    ipv6_mode = getattr(args, "mgmt_ipv6_mode", None)
+    if ipv6_mode:
+        lines.extend(["ipv6 unicast-routing", "!"])
+
     if mgmt_vrf:
-        if csr_style:
-            lines.extend(
-                [
-                    f"vrf definition {mgmt_vrf}",
-                    " address-family ipv4",
-                    " exit-address-family",
-                    "!",
-                ]
-            )
+        if csr_style or ipv6_mode:
+            vrf_lines = [
+                f"vrf definition {mgmt_vrf}",
+                f" rd 1:{mgmt_slot}",
+                " address-family ipv4",
+                " exit-address-family",
+            ]
+            if ipv6_mode:
+                vrf_lines.extend(
+                    [
+                        " address-family ipv6",
+                        " exit-address-family",
+                    ]
+                )
+            vrf_lines.append("!")
+            lines.extend(vrf_lines)
         else:
             lines.extend(
                 [
@@ -762,9 +790,15 @@ def _render_bootstrap_config(cfg: Config, node: TopogenNode, args: Namespace) ->
     lines.append(f"interface {if_label}")
     lines.append(" description OOB Management")
     if mgmt_vrf:
-        fwd = "vrf forwarding" if csr_style else "ip vrf forwarding"
+        fwd = "vrf forwarding" if (csr_style or ipv6_mode) else "ip vrf forwarding"
         lines.append(f" {fwd} {mgmt_vrf}")
-    if mgmt_bridge:
+    if ipv6_mode:
+        lines.append(" ipv6 enable")
+        if ipv6_mode == "slaac":
+            lines.append(" ipv6 address autoconfig")
+        elif ipv6_mode == "dhcpv6":
+            lines.append(" ipv6 address dhcp")
+    elif mgmt_bridge:
         lines.append(" ip address dhcp")
     else:
         mgmt_iface = next(
@@ -1888,14 +1922,7 @@ class Renderer:
             )
 
             # Build mgmt context for template
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(self.args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(self.args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(self.args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(self.args, "ntp_server", None):
                 ntp_ctx = {
@@ -2702,6 +2729,10 @@ class Renderer:
                 args_bits.append(f"--mgmt-vrf {args.mgmt_vrf}")
             if getattr(args, "mgmt_bridge", False):
                 args_bits.append("--mgmt-bridge")
+            if getattr(args, "mgmt_ipv6_mode", None):
+                args_bits.append(f"--mgmt-ipv6-mode {args.mgmt_ipv6_mode}")
+            if getattr(args, "mgmt_ipv6_cidr", None):
+                args_bits.append(f"--mgmt-ipv6-cidr {args.mgmt_ipv6_cidr}")
         if getattr(args, "ntp_server", None):
             args_bits.append(f"--ntp {args.ntp_server}")
             if getattr(args, "ntp_inband", False):
@@ -2987,14 +3018,7 @@ class Renderer:
             nac_router_nodes.append(nac_node)
 
             # Build mgmt context for template
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ntp_ctx = {
@@ -3094,14 +3118,7 @@ class Renderer:
                     )
                 ],
             )
-            ks_mgmt_ctx = None
-            if enable_mgmt:
-                ks_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ks_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ks_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ks_ntp_ctx = {"server": args.ntp_server, "vrf": getattr(args, "ntp_vrf", None)}
@@ -3164,14 +3181,7 @@ class Renderer:
                 ca_base_tpl = env.get_template(f"csr-eigrp{Renderer.J2SUFFIX}")
             except TemplateNotFound:
                 raise TopogenError("CA template not found: csr-eigrp")
-            ca_mgmt_ctx = None
-            if enable_mgmt:
-                ca_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ca_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ca_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ca_ntp_ctx = {
@@ -3767,14 +3777,7 @@ class Renderer:
             loopback_ip = IPv4Interface(f"{l_base}.{hi}.{lo}/32")
 
             # Build mgmt context for template
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ntp_ctx = {
@@ -3910,14 +3913,7 @@ class Renderer:
                     )
                 ],
             )
-            ks_mgmt_ctx = None
-            if enable_mgmt:
-                ks_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ks_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ks_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ks_ntp_ctx = {"server": args.ntp_server, "vrf": getattr(args, "ntp_vrf", None)}
@@ -3989,14 +3985,7 @@ class Renderer:
                 raise TopogenError("CA template not found: csr-eigrp")
 
             # Render base config with EIGRP routing
-            ca_mgmt_ctx = None
-            if enable_mgmt:
-                ca_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ca_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ca_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ca_ntp_ctx = {
@@ -4557,14 +4546,7 @@ class Renderer:
             _append_nac_mgmt_interface(node, args, n)
             nac_router_nodes.append(node)
             # Build mgmt context for template
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ntp_ctx = {
@@ -4651,14 +4633,7 @@ class Renderer:
                     )
                 ],
             )
-            ks_mgmt_ctx = None
-            if enable_mgmt:
-                ks_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ks_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ks_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ks_ntp_ctx = {
@@ -4750,14 +4725,7 @@ class Renderer:
                     )
                 ],
             )
-            ca_mgmt_ctx = None
-            if enable_mgmt:
-                ca_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ca_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ca_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ca_ntp_ctx = {
@@ -5314,14 +5282,7 @@ class Renderer:
             _append_nac_mgmt_interface(node, args, n)
             nac_router_nodes.append(node)
             # Build mgmt/ntp context for template
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ntp_ctx = {
@@ -5417,14 +5378,7 @@ class Renderer:
                     )
                 ],
             )
-            ks_mgmt_ctx = None
-            if enable_mgmt:
-                ks_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ks_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ks_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ks_ntp_ctx = {"server": args.ntp_server, "vrf": getattr(args, "ntp_vrf", None)}
@@ -5502,14 +5456,7 @@ class Renderer:
                 raise TopogenError(f"CA template not found: {ca_template_name}")
 
             # Render base config with routing protocol
-            ca_mgmt_ctx = None
-            if enable_mgmt:
-                ca_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            ca_mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ca_ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ca_ntp_ctx = {
@@ -6097,14 +6044,7 @@ class Renderer:
             _append_nac_mgmt_interface(node_obj, args, node_index + 1)
             nac_router_nodes.append(node_obj)
 
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ntp_ctx = {
@@ -6622,14 +6562,7 @@ class Renderer:
             _append_nac_mgmt_interface(node_obj, args, idx + 1)
             nac_router_nodes.append(node_obj)
 
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(args, "ntp_server", None):
                 ntp_ctx = {
@@ -6932,14 +6865,7 @@ class Renderer:
             l_addr = IPv4Interface(f"{l_base}.{hi}.{lo}/32")
 
             # Build mgmt context for template
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(self.args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(self.args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(self.args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(self.args, "ntp_server", None):
                 ntp_ctx = {
@@ -7019,14 +6945,7 @@ class Renderer:
             ca_l_addr = IPv4Interface(f"{l_base}.255.254/32")
 
             # Build mgmt/ntp context for CA
-            ca_mgmt_ctx = None
-            if enable_mgmt:
-                ca_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(self.args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(self.args, "mgmt_gw", None),
-                }
+            ca_mgmt_ctx = _build_mgmt_context(self.args, mgmt_slot=mgmt_slot)
             ca_ntp_ctx = None
             if getattr(self.args, "ntp_server", None):
                 ca_ntp_ctx = {
@@ -7113,14 +7032,7 @@ class Renderer:
                 loader=_jinja2.FileSystemLoader(_ks_tpl_dir),
             ).get_template(f"csr-getvpn-ks{Renderer.J2SUFFIX}")
 
-            ks_mgmt_ctx = None
-            if enable_mgmt:
-                ks_mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(self.args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(self.args, "mgmt_gw", None),
-                }
+            ks_mgmt_ctx = _build_mgmt_context(self.args, mgmt_slot=mgmt_slot)
             ks_ntp_ctx = None
             if getattr(self.args, "ntp_server", None):
                 ks_ntp_ctx = {
@@ -7288,14 +7200,7 @@ class Renderer:
             )
 
             # Build mgmt context for template
-            mgmt_ctx = None
-            if enable_mgmt:
-                mgmt_ctx = {
-                    "enabled": True,
-                    "slot": mgmt_slot,
-                    "vrf": getattr(self.args, "mgmt_vrf", None) or "Mgmt-vrf",
-                    "gw": getattr(self.args, "mgmt_gw", None),
-                }
+            mgmt_ctx = _build_mgmt_context(self.args, mgmt_slot=mgmt_slot)
             ntp_ctx = None
             if getattr(self.args, "ntp_server", None):
                 ntp_ctx = {

--- a/src/topogen/templates/csr-dmvpn.jinja2
+++ b/src/topogen/templates/csr-dmvpn.jinja2
@@ -255,11 +255,19 @@ router eigrp 100
 !
 {%- endif %}
 {%- if mgmt and mgmt.enabled %}
+{%- if mgmt.ipv6_mode %}
+ipv6 unicast-routing
+!
+{%- endif %}
 {%- if mgmt.vrf %}
 vrf definition {{ mgmt.vrf }}
  rd 1:{{ mgmt.slot }}
  address-family ipv4
  exit-address-family
+{%- if mgmt.ipv6_mode %}
+ address-family ipv6
+ exit-address-family
+{%- endif %}
 !
 {%- endif %}
 interface GigabitEthernet{{ mgmt.slot }}
@@ -267,7 +275,16 @@ interface GigabitEthernet{{ mgmt.slot }}
 {%- if mgmt.vrf %}
  vrf forwarding {{ mgmt.vrf }}
 {%- endif %}
+{%- if mgmt.ipv6_mode %}
+ ipv6 enable
+{%- if mgmt.ipv6_mode == 'slaac' %}
+ ipv6 address autoconfig
+{%- elif mgmt.ipv6_mode == 'dhcpv6' %}
+ ipv6 address dhcp
+{%- endif %}
+{%- else %}
  ip address dhcp
+{%- endif %}
  no cdp enable
  no shutdown
 !

--- a/src/topogen/templates/csr1000v.jinja2
+++ b/src/topogen/templates/csr1000v.jinja2
@@ -27,7 +27,7 @@ cdp run
 !
 {%- set ns = namespace(seen={}) %}
 {%- for iface in node.interfaces %}
-{%- if iface.vrf and not ns.seen.get(iface.vrf) %}
+{%- if iface.vrf and (iface.description | default('')) != 'OOB Management' and not ns.seen.get(iface.vrf) and not (mgmt and mgmt.enabled and mgmt.ipv6_mode and mgmt.vrf and iface.vrf == mgmt.vrf) %}
 vrf definition {{ iface.vrf }}
  rd 1:1
  address-family ipv4
@@ -54,7 +54,7 @@ router ospf 1
     {%- endif %}
 !
 {%- set ns_ospf = namespace(seen={}) %}
-{%- for iface in node.interfaces if iface.address and iface.vrf %}
+{%- for iface in node.interfaces if iface.address and iface.vrf and (iface.description | default('')) != 'OOB Management' %}
 {%- if not ns_ospf.seen.get(iface.vrf) %}
 router ospf 2 vrf {{ iface.vrf }}
     {%- set _ = ns_ospf.seen.update({iface.vrf: true}) %}
@@ -81,11 +81,19 @@ interface GigabitEthernet{{ iface.slot + 1 }}
 {%- endfor %}
 !
 {%- if mgmt and mgmt.enabled %}
+{%- if mgmt.ipv6_mode %}
+ipv6 unicast-routing
+!
+{%- endif %}
 {%- if mgmt.vrf %}
 vrf definition {{ mgmt.vrf }}
  rd 1:{{ mgmt.slot }}
  address-family ipv4
  exit-address-family
+{%- if mgmt.ipv6_mode %}
+ address-family ipv6
+ exit-address-family
+{%- endif %}
 !
 {%- endif %}
 interface GigabitEthernet{{ mgmt.slot }}
@@ -93,7 +101,16 @@ interface GigabitEthernet{{ mgmt.slot }}
     {%- if mgmt.vrf %}
     vrf forwarding {{ mgmt.vrf }}
     {%- endif %}
+    {%- if mgmt.ipv6_mode %}
+    ipv6 enable
+    {%- if mgmt.ipv6_mode == 'slaac' %}
+    ipv6 address autoconfig
+    {%- elif mgmt.ipv6_mode == 'dhcpv6' %}
+    ipv6 address dhcp
+    {%- endif %}
+    {%- else %}
     ip address dhcp
+    {%- endif %}
     no cdp enable
     no shutdown
 !

--- a/src/topogen/templates/iosv.jinja2
+++ b/src/topogen/templates/iosv.jinja2
@@ -27,7 +27,7 @@ cdp run
 !
 {%- set ns = namespace(seen={}) %}
 {%- for iface in node.interfaces %}
-{%- if iface.vrf and not ns.seen.get(iface.vrf) %}
+{%- if iface.vrf and (iface.description | default('')) != 'OOB Management' and not ns.seen.get(iface.vrf) and not (mgmt and mgmt.enabled and mgmt.ipv6_mode and mgmt.vrf and iface.vrf == mgmt.vrf) %}
 ip vrf {{ iface.vrf }}
  rd 1:1
 !
@@ -52,7 +52,7 @@ router ospf 1
     {%- endif %}
 !
 {%- set ns_ospf = namespace(seen={}) %}
-{%- for iface in node.interfaces if iface.address and iface.vrf %}
+{%- for iface in node.interfaces if iface.address and iface.vrf and (iface.description | default('')) != 'OOB Management' %}
 {%- if not ns_ospf.seen.get(iface.vrf) %}
 router ospf 2 vrf {{ iface.vrf }}
     {%- set _ = ns_ospf.seen.update({iface.vrf: true}) %}
@@ -79,17 +79,44 @@ interface GigabitEthernet0/{{ iface.slot }}
 {%- endfor %}
 !
 {%- if mgmt and mgmt.enabled %}
+{%- if mgmt.ipv6_mode %}
+ipv6 unicast-routing
+!
+{%- endif %}
 {%- if mgmt.vrf %}
+{%- if mgmt.ipv6_mode %}
+vrf definition {{ mgmt.vrf }}
+ rd 1:{{ mgmt.slot }}
+ address-family ipv4
+ exit-address-family
+ address-family ipv6
+ exit-address-family
+!
+{%- else %}
 ip vrf {{ mgmt.vrf }}
  rd 1:{{ mgmt.slot }}
 !
 {%- endif %}
+{%- endif %}
 interface GigabitEthernet0/{{ mgmt.slot }}
     description OOB Management
     {%- if mgmt.vrf %}
+    {%- if mgmt.ipv6_mode %}
+    vrf forwarding {{ mgmt.vrf }}
+    {%- else %}
     ip vrf forwarding {{ mgmt.vrf }}
     {%- endif %}
+    {%- endif %}
+    {%- if mgmt.ipv6_mode %}
+    ipv6 enable
+    {%- if mgmt.ipv6_mode == 'slaac' %}
+    ipv6 address autoconfig
+    {%- elif mgmt.ipv6_mode == 'dhcpv6' %}
+    ipv6 address dhcp
+    {%- endif %}
+    {%- else %}
     ip address dhcp
+    {%- endif %}
     no cdp enable
     no shutdown
 !

--- a/tests/test_mgmt_ipv6_vrf.py
+++ b/tests/test_mgmt_ipv6_vrf.py
@@ -1,0 +1,320 @@
+# File Chain (see DEVELOPER.md):
+# Doc Version: v1.0.0
+# Date Modified: 2026-06-11
+#
+# Purpose: TG-190 CP1 — offline render asserts for OOB IPv6 mgmt in VRF.
+# Blast Radius: Test-only.
+
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from argparse import Namespace
+
+from topogen.main import main  # pylint: disable=wrong-import-position
+from topogen.config import Config  # pylint: disable=wrong-import-position
+from topogen.models import TopogenInterface, TopogenNode  # pylint: disable=wrong-import-position
+from topogen.render import _render_bootstrap_config  # pylint: disable=wrong-import-position
+
+
+def _extract_router_config(cml_yaml: Path, label: str = "R1") -> str:
+    data = yaml.safe_load(cml_yaml.read_text(encoding="utf-8"))
+    for node in data.get("nodes", []):
+        if node.get("label") == label:
+            cfg = node.get("configuration", "")
+            if isinstance(cfg, list):
+                return cfg[0].get("content", "") if cfg else ""
+            return str(cfg)
+    raise AssertionError(f"node {label} not found in {cml_yaml}")
+
+
+def _oob_block(config: str, iface_pattern: str) -> str:
+    match = re.search(
+        rf"(interface {iface_pattern}\b.*?)(?=\ninterface |\n!|\nend\b)",
+        config,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if not match:
+        raise AssertionError(f"OOB interface {iface_pattern} not found")
+    return match.group(1)
+
+
+class TestMgmtIpv6VrfOfflineRender(unittest.TestCase):
+    def _run_offline_config(self, argv: list[str], label: str = "R1") -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_file = Path(tmp) / "lab.yaml"
+            with patch.object(sys, "argv", ["topogen", *argv, "--offline-yaml", str(out_file)]):
+                rc = main()
+            self.assertEqual(rc, 0, f"topogen failed for argv={argv}")
+            return _extract_router_config(out_file, label)
+
+    def test_csr_slaac_renders_ipv6_oob_and_vrf_af(self):
+        config = self._run_offline_config(
+            [
+                "2",
+                "--mode",
+                "simple",
+                "-T",
+                "csr1000v",
+                "--device-template",
+                "csr1000v",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+                "--mgmt-ipv6-mode",
+                "slaac",
+            ]
+        )
+        self.assertIn("address-family ipv6", config)
+        self.assertIn("vrf definition Mgmt-vrf", config)
+        self.assertRegex(config, r"interface GigabitEthernet5\b")
+        oob = _oob_block(config, r"GigabitEthernet5")
+        self.assertIn("vrf forwarding Mgmt-vrf", oob)
+        self.assertIn("ipv6 address autoconfig", oob)
+        self.assertNotIn("ip address dhcp", oob)
+
+    def test_iosv_dhcpv6_renders_ipv6_oob(self):
+        config = self._run_offline_config(
+            [
+                "2",
+                "--mode",
+                "simple",
+                "-T",
+                "iosv",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+                "--mgmt-ipv6-mode",
+                "dhcpv6",
+            ]
+        )
+        self.assertIn("vrf definition Mgmt-vrf", config)
+        self.assertIn("address-family ipv6", config)
+        self.assertRegex(config, r"interface GigabitEthernet0/5\b")
+        oob = _oob_block(config, r"GigabitEthernet0/5")
+        self.assertIn("vrf forwarding Mgmt-vrf", oob)
+        self.assertIn("ipv6 address dhcp", oob)
+        self.assertNotIn("ip address dhcp", oob)
+
+    def test_flat_slaac_with_mgmt_bridge_renders_ext_conn_and_ipv6_oob(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_file = Path(tmp) / "lab.yaml"
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "topogen",
+                    "2",
+                    "--mode",
+                    "flat",
+                    "-T",
+                    "iosv",
+                    "--device-template",
+                    "iosv",
+                    "--mgmt",
+                    "--mgmt-vrf",
+                    "Mgmt-vrf",
+                    "--mgmt-bridge",
+                    "--mgmt-ipv6-mode",
+                    "slaac",
+                    "--mgmt-ipv6-cidr",
+                    "fd00:10:254::/64",
+                    "--offline-yaml",
+                    str(out_file),
+                ],
+            ):
+                rc = main()
+            self.assertEqual(rc, 0)
+            data = yaml.safe_load(out_file.read_text(encoding="utf-8"))
+            labels = {node.get("label") for node in data.get("nodes", [])}
+            self.assertIn("ext-conn-mgmt", labels)
+            self.assertIn("SWoob0", labels)
+            links = data.get("links", [])
+            ext_id = next(
+                n["id"] for n in data["nodes"] if n.get("label") == "ext-conn-mgmt"
+            )
+            swoob0_id = next(n["id"] for n in data["nodes"] if n.get("label") == "SWoob0")
+            bridge_link = next(
+                (
+                    link
+                    for link in links
+                    if {link.get("n1"), link.get("n2")} == {ext_id, swoob0_id}
+                ),
+                None,
+            )
+            self.assertIsNotNone(bridge_link, "ext-conn-mgmt must link to SWoob0")
+            config = _extract_router_config(out_file, "R1")
+            self.assertIn("vrf definition Mgmt-vrf", config)
+            oob = _oob_block(config, r"GigabitEthernet0/5")
+            self.assertIn("vrf forwarding Mgmt-vrf", oob)
+            self.assertIn("ipv6 address autoconfig", oob)
+            self.assertNotIn("ip address dhcp", oob)
+
+    def test_default_ipv4_mgmt_unchanged(self):
+        config = self._run_offline_config(
+            [
+                "2",
+                "--mode",
+                "simple",
+                "-T",
+                "csr1000v",
+                "--device-template",
+                "csr1000v",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+            ]
+        )
+        oob = _oob_block(config, r"GigabitEthernet5")
+        self.assertIn("ip address dhcp", oob)
+        self.assertNotIn("ipv6 address autoconfig", oob)
+        self.assertNotIn("ipv6 address dhcp", oob)
+        self.assertNotIn("address-family ipv6", config)
+
+    def test_flat_ipv4_mgmt_no_duplicate_vrf_blocks(self):
+        config = self._run_offline_config(
+            [
+                "2",
+                "--mode",
+                "flat",
+                "-T",
+                "iosv",
+                "--device-template",
+                "iosv",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+                "--mgmt-bridge",
+            ]
+        )
+        self.assertEqual(config.count("ip vrf Mgmt-vrf"), 1)
+        self.assertNotIn("vrf definition Mgmt-vrf", config)
+        oob = _oob_block(config, r"GigabitEthernet0/5")
+        self.assertIn("ip vrf forwarding Mgmt-vrf", oob)
+        self.assertIn("ip address dhcp", oob)
+
+    def test_flat_ipv6_slaac_no_ip_vrf_conflict(self):
+        config = self._run_offline_config(
+            [
+                "2",
+                "--mode",
+                "flat",
+                "-T",
+                "iosv",
+                "--device-template",
+                "iosv",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+                "--mgmt-bridge",
+                "--mgmt-ipv6-mode",
+                "slaac",
+            ]
+        )
+        self.assertNotIn("ip vrf Mgmt-vrf", config)
+        self.assertEqual(config.count("vrf definition Mgmt-vrf"), 1)
+        self.assertIn("address-family ipv6", config)
+        oob = _oob_block(config, r"GigabitEthernet0/5")
+        self.assertIn("vrf forwarding Mgmt-vrf", oob)
+        self.assertIn("ipv6 address autoconfig", oob)
+        self.assertNotIn("ip address dhcp", oob)
+
+    def test_flat_ipv6_slaac_oob_no_shutdown_single_block(self):
+        """OOB Gi must be no shutdown once; NaC iface must not duplicate Gi0/5."""
+        config = self._run_offline_config(
+            [
+                "4",
+                "--mode",
+                "flat",
+                "-T",
+                "iosv",
+                "--device-template",
+                "iosv",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+                "--mgmt-bridge",
+                "--mgmt-ipv6-mode",
+                "slaac",
+            ]
+        )
+        self.assertEqual(len(re.findall(r"interface GigabitEthernet0/5\b", config)), 1)
+        oob = _oob_block(config, r"GigabitEthernet0/5")
+        self.assertIn("no shutdown", oob)
+        self.assertNotRegex(oob, r"(?m)^\s+shutdown\s*$")
+        after_oob = config.split(oob, 1)[-1]
+        self.assertNotRegex(after_oob, r"interface GigabitEthernet0/5\b")
+
+    def test_iosv_bootstrap_ipv6_slaac_uses_vrf_definition(self):
+        cfg = Config(
+            username="cisco",
+            password="cisco",
+            domainname="virl.lab",
+            nameserver="8.8.8.8",
+        )
+        node = TopogenNode(
+            hostname="R1",
+            loopback=None,
+            interfaces=[
+                TopogenInterface(
+                    description="OOB Management",
+                    slot=5,
+                    vrf="Mgmt-vrf",
+                )
+            ],
+        )
+        args = Namespace(
+            dev_template="iosv",
+            template="iosv",
+            enable_mgmt=True,
+            mgmt_vrf="Mgmt-vrf",
+            mgmt_slot=5,
+            mgmt_bridge=True,
+            mgmt_gw=None,
+            mgmt_ipv6_mode="slaac",
+        )
+        config = _render_bootstrap_config(cfg, node, args)
+        self.assertNotIn("ip vrf Mgmt-vrf", config)
+        self.assertEqual(config.count("vrf definition Mgmt-vrf"), 1)
+        self.assertIn("address-family ipv6", config)
+        oob = _oob_block(config, r"GigabitEthernet0/5")
+        self.assertIn("vrf forwarding Mgmt-vrf", oob)
+        self.assertIn("ipv6 address autoconfig", oob)
+
+    def test_mgmt_global_vrf_omits_vrf_stanzas(self):
+        config = self._run_offline_config(
+            [
+                "2",
+                "--mode",
+                "simple",
+                "-T",
+                "iosv",
+                "--device-template",
+                "iosv",
+                "--mgmt",
+                "--mgmt-vrf",
+                "global",
+                "--mgmt-bridge",
+            ]
+        )
+        self.assertNotIn("ip vrf ", config)
+        self.assertNotIn("vrf definition ", config)
+        oob = _oob_block(config, r"GigabitEthernet0/5")
+        self.assertNotIn("vrf forwarding", oob)
+        self.assertNotIn("ip vrf forwarding", oob)
+        self.assertIn("ip address dhcp", oob)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nac_cli_guardrails.py
+++ b/tests/test_nac_cli_guardrails.py
@@ -25,11 +25,13 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from topogen.main import (  # pylint: disable=wrong-import-position
+    MGMT_IPV4_OOB_NODE_LIMIT,
     create_argparser,
     main,
     normalize_template_inputs,
     validate_bootstrap_guardrails,
     validate_cml2_lifecycle_guardrails,
+    validate_mgmt_ipv6_guardrails,
     validate_nac_mvp_guardrails,
     validate_nodes_for_mode,
 )
@@ -46,6 +48,7 @@ class TestNacCliGuardrails(unittest.TestCase):
         validate_nac_mvp_guardrails(args, self.parser)
         validate_bootstrap_guardrails(args, self.parser)
         validate_cml2_lifecycle_guardrails(args, self.parser)
+        validate_mgmt_ipv6_guardrails(args, self.parser)
         return args
 
     def _run_main_exit(self, argv):
@@ -391,6 +394,150 @@ class TestNacCliGuardrails(unittest.TestCase):
         )
         self.assertEqual(args.template, "csr1000v")
         self.assertEqual(args.dev_template, "csr1000v")
+
+    def test_mgmt_ipv6_mode_requires_mgmt(self):
+        with self.assertRaises(SystemExit) as cm:
+            with redirect_stderr(io.StringIO()) as stderr:
+                self._parse_and_validate(
+                    [
+                        "2",
+                        "--mode",
+                        "simple",
+                        "--offline-yaml",
+                        "out/iosv-test.yaml",
+                        "--mgmt-ipv6-mode",
+                        "slaac",
+                    ]
+                )
+        self.assertNotEqual(cm.exception.code, 0)
+        self.assertIn("--mgmt-ipv6-mode requires --mgmt", stderr.getvalue())
+
+    def test_mgmt_ipv6_mode_rejects_global_vrf(self):
+        with self.assertRaises(SystemExit) as cm:
+            with redirect_stderr(io.StringIO()) as stderr:
+                args = self.parser.parse_args(
+                    [
+                        "2",
+                        "--mode",
+                        "simple",
+                        "--offline-yaml",
+                        "out/iosv-test.yaml",
+                        "--mgmt",
+                        "--mgmt-vrf",
+                        "global",
+                        "--mgmt-ipv6-mode",
+                        "slaac",
+                    ]
+                )
+                normalize_template_inputs(args)
+                if args.mgmt_vrf and args.mgmt_vrf.lower() == "global":
+                    args.mgmt_vrf = None
+                validate_mgmt_ipv6_guardrails(args, self.parser)
+        self.assertNotEqual(cm.exception.code, 0)
+        self.assertIn("named --mgmt-vrf", stderr.getvalue())
+
+    def test_valid_mgmt_ipv6_slaac_with_mgmt_bridge(self):
+        args = self._parse_and_validate(
+            [
+                "2",
+                "--mode",
+                "flat",
+                "--offline-yaml",
+                "out/iosv-ipv6-bridge.yaml",
+                "--mgmt",
+                "--mgmt-bridge",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+                "--mgmt-ipv6-mode",
+                "slaac",
+                "--mgmt-ipv6-cidr",
+                "fd00:10:254::/64",
+            ]
+        )
+        self.assertTrue(args.enable_mgmt)
+        self.assertTrue(args.mgmt_bridge)
+        self.assertEqual(args.mgmt_ipv6_mode, "slaac")
+
+    def test_valid_mgmt_ipv6_slaac_command_shape(self):
+        args = self._parse_and_validate(
+            [
+                "2",
+                "--mode",
+                "simple",
+                "--offline-yaml",
+                "out/iosv-ipv6.yaml",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+                "--mgmt-ipv6-mode",
+                "slaac",
+                "--mgmt-ipv6-cidr",
+                "fd00:10:254::/64",
+            ]
+        )
+        self.assertTrue(args.enable_mgmt)
+        self.assertEqual(args.mgmt_ipv6_mode, "slaac")
+        self.assertEqual(args.mgmt_ipv6_cidr, "fd00:10:254::/64")
+
+    def test_mgmt_ipv4_oob_rejected_at_scale_without_ipv6_mode(self):
+        with self.assertRaises(SystemExit) as cm:
+            with redirect_stderr(io.StringIO()) as stderr:
+                self._parse_and_validate(
+                    [
+                        "300",
+                        "--mode",
+                        "flat",
+                        "--offline-yaml",
+                        "out/large-flat.yaml",
+                        "--nac",
+                        "--mgmt",
+                        "--mgmt-vrf",
+                        "Mgmt-vrf",
+                        "--mgmt-bridge",
+                    ]
+                )
+        self.assertNotEqual(cm.exception.code, 0)
+        err = stderr.getvalue()
+        self.assertIn("300 nodes", err)
+        self.assertIn("--mgmt-ipv6-mode", err)
+        self.assertIn("IPv4 OOB", err)
+
+    def test_mgmt_ipv4_oob_allowed_below_scale_threshold(self):
+        below = str(MGMT_IPV4_OOB_NODE_LIMIT - 1)
+        args = self._parse_and_validate(
+            [
+                below,
+                "--mode",
+                "flat",
+                "--offline-yaml",
+                "out/medium-flat.yaml",
+                "--nac",
+                "--mgmt",
+                "--mgmt-vrf",
+                "Mgmt-vrf",
+            ]
+        )
+        self.assertTrue(args.enable_mgmt)
+        self.assertIsNone(args.mgmt_ipv6_mode)
+
+    def test_mgmt_ipv4_oob_at_threshold_requires_ipv6_mode(self):
+        with self.assertRaises(SystemExit) as cm:
+            with redirect_stderr(io.StringIO()) as stderr:
+                self._parse_and_validate(
+                    [
+                        str(MGMT_IPV4_OOB_NODE_LIMIT),
+                        "--mode",
+                        "flat",
+                        "--offline-yaml",
+                        "out/at-threshold-flat.yaml",
+                        "--nac",
+                        "--mgmt",
+                        "--mgmt-vrf",
+                        "Mgmt-vrf",
+                    ]
+                )
+        self.assertNotEqual(cm.exception.code, 0)
+        self.assertIn("--mgmt-ipv6-mode", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_nac_mgmt_ipv6_slaac.py
+++ b/tests/test_sync_nac_mgmt_ipv6_slaac.py
@@ -1,0 +1,172 @@
+# File Chain (see DEVELOPER.md):
+# Purpose: TG-190 — unit tests for IPv6 SLAAC NaC mgmt sync parse/patch logic.
+# Blast Radius: Test-only.
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from nac_mgmt_sync_lib import patch_nac_files  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "sync_nac_mgmt_ipv6_slaac",
+    SCRIPTS / "sync-nac-mgmt-ipv6-slaac.py",
+)
+_ipv6_mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_ipv6_mod)
+parse_mgmt_ipv6 = _ipv6_mod.parse_mgmt_ipv6
+
+IFACE = "GigabitEthernet0/5"
+
+BRIEF_GLOBAL_SLAAC = """
+Interface              IPv6-Address                  Status
+GigabitEthernet0/0     unassigned                    [down/down]
+GigabitEthernet0/5     [up/up]
+    FE80::5054:FF:FE58:4AA4
+    2600:1700:21F8:7EC0:5054:FF:FE58:4AA4
+GigabitEthernet0/1     unassigned                    [down/down]
+"""
+
+BRIEF_FD00_ONLY = """
+GigabitEthernet0/5     [up/up]
+    FE80::1
+    fd00:10:254:0:5054:ff:fe12:3456
+"""
+
+BRIEF_LINK_LOCAL_ONLY = """
+GigabitEthernet0/5     [up/up]
+    FE80::5054:FF:FE58:4AA4
+"""
+
+DETAIL_GLOBAL = """
+GigabitEthernet0/5 is up, line protocol is up
+  IPv6 is enabled, link-local address is FE80::5054:FF:FE58:4AA4
+  Global unicast address(es):
+    2600:1700:21F8:7EC0:5054:FF:FE58:4AA4, subnet is 2600:1700:21F8:7EC0::/64 [VALID]
+  Joined group address(es):
+    FF02::1
+  MTU is 1500 bytes
+"""
+
+BRIEF_COMPACT_LINE = """
+GigabitEthernet0/5     2600:1700:21F8:7EC0:5054:FF:FE58:4AA4
+GigabitEthernet0/1     unassigned
+"""
+
+
+def _write_min_nac_tree(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "nac.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "iosxe": {
+                    "devices": [
+                        {"name": "iosv-01", "configuration": {"system": {"hostname": "R1"}}},
+                        {"name": "iosv-02", "configuration": {"system": {"hostname": "R2"}}},
+                    ]
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (root / "inventory.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "all": {
+                    "hosts": {
+                        "iosv-01": {"ansible_host": "", "platform": "iosxe"},
+                        "iosv-02": {"ansible_host": "", "platform": "iosxe"},
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (root / "devices.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "devices": [
+                    {"name": "iosv-01", "hostname": "R1", "mgmt_ip": ""},
+                    {"name": "iosv-02", "hostname": "R2", "mgmt_ip": ""},
+                ]
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestParseMgmtIpv6(unittest.TestCase):
+    def test_parses_global_slaac_from_brief(self):
+        got = parse_mgmt_ipv6(BRIEF_GLOBAL_SLAAC, IFACE)
+        self.assertEqual(got, "2600:1700:21f8:7ec0:5054:ff:fe58:4aa4")
+
+    def test_prefers_global_over_link_local(self):
+        got = parse_mgmt_ipv6(BRIEF_FD00_ONLY, IFACE)
+        self.assertEqual(got, "fd00:10:254:0:5054:ff:fe12:3456")
+
+    def test_link_local_only_returns_none(self):
+        self.assertIsNone(parse_mgmt_ipv6(BRIEF_LINK_LOCAL_ONLY, IFACE))
+
+    def test_parses_detail_output(self):
+        got = parse_mgmt_ipv6(DETAIL_GLOBAL, IFACE)
+        self.assertEqual(got, "2600:1700:21f8:7ec0:5054:ff:fe58:4aa4")
+
+    def test_parses_compact_single_line(self):
+        got = parse_mgmt_ipv6(BRIEF_COMPACT_LINE, IFACE)
+        self.assertEqual(got, "2600:1700:21f8:7ec0:5054:ff:fe58:4aa4")
+
+    def test_missing_interface_returns_none(self):
+        self.assertIsNone(parse_mgmt_ipv6(BRIEF_COMPACT_LINE, "GigabitEthernet0/99"))
+
+
+class TestPatchNacFilesIpv6(unittest.TestCase):
+    def test_patches_host_inventory_and_devices(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            nac_root = Path(tmp)
+            _write_min_nac_tree(nac_root)
+            mapping = {
+                "iosv-01": "2600:1700:21f8:7ec0:5054:ff:fe58:4aa4",
+                "iosv-02": "fd00:10:254:0:5054:ff:fe12:3456",
+            }
+            patch_nac_files(nac_root, mapping)
+
+            nac = yaml.safe_load((nac_root / "nac.yaml").read_text(encoding="utf-8"))
+            by_name = {d["name"]: d for d in nac["iosxe"]["devices"]}
+            self.assertEqual(by_name["iosv-01"]["host"], mapping["iosv-01"])
+
+            inv = yaml.safe_load((nac_root / "inventory.yaml").read_text(encoding="utf-8"))
+            self.assertEqual(
+                inv["all"]["hosts"]["iosv-02"]["ansible_host"],
+                mapping["iosv-02"],
+            )
+
+            dev = yaml.safe_load((nac_root / "devices.yaml").read_text(encoding="utf-8"))
+            by_dev = {d["name"]: d for d in dev["devices"]}
+            self.assertEqual(by_dev["iosv-01"]["mgmt_ip"], mapping["iosv-01"])
+
+            report = {
+                "synced": len(mapping),
+                "mapping": mapping,
+            }
+            report_path = nac_root / "mgmt_ipv6_sync.json"
+            report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+            loaded = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(loaded["synced"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add IPv6 SLAAC management sync (sync-nac-mgmt-ipv6-slaac.py, shared 
ac_mgmt_sync_lib.py) and lab SSH fan-out helper under scripts/.
- Update IOS/CSR templates and NAC CLI guardrails for CP1 (mgmt IPv6 VRF, checkpoint docs, DEVELOPER.md).
- Add unit tests for mgmt IPv6 VRF rendering and SLAAC sync behavior.

## Test plan
- [ ] `pytest tests/test_mgmt_ipv6_vrf.py tests/test_sync_nac_mgmt_ipv6_slaac.py tests/test_nac_cli_guardrails.py`
- [ ] Regenerate a small topology and confirm mgmt IPv6 / VRF stanzas in rendered config
- [ ] Dry-run SLAAC sync against lab inventory (no destructive apply unless intended)

Made with [Cursor](https://cursor.com)