### PR TITLE
fix: suppress IPv6 RA on OOB management interfaces

### DIFF
--- a/src/topogen/templates/_csr_mgmt_oob.jinja2
+++ b/src/topogen/templates/_csr_mgmt_oob.jinja2
@@ -45,6 +45,7 @@ interface GigabitEthernet{{ mgmt.slot }}
     {%- endif %}
     {%- if ipv6_mode %}
     ipv6 enable
+    ipv6 nd ra suppress all
     {%- if ipv6_mode == 'slaac' %}
     ipv6 address autoconfig
     {%- elif ipv6_mode == 'dhcpv6' %}

--- a/src/topogen/templates/_iosv_mgmt_oob.jinja2
+++ b/src/topogen/templates/_iosv_mgmt_oob.jinja2
@@ -52,6 +52,7 @@ interface GigabitEthernet0/{{ mgmt.slot }}
     {%- endif %}
     {%- if ipv6_mode %}
     ipv6 enable
+    ipv6 nd ra suppress all
     {%- if ipv6_mode == 'slaac' %}
     ipv6 address autoconfig
     {%- elif ipv6_mode == 'dhcpv6' %}


### PR DESCRIPTION

PR body:
## Summary
This PR contains only the RA suppression change for OOB management interfaces.

## What Changed
- Added ipv6 nd ra suppress all immediately after ipv6 enable in:
  - _csr_mgmt_oob.jinja2
  - _iosv_mgmt_oob.jinja2

## Behavior
- Applies only when IPv6 management mode is enabled.
- Covers static, SLAAC, and DHCPv6 management modes.
- Prevents unsolicited RA emission on bridged OOB management segments.

## Scope
- No unrelated refactors.
- No additional feature changes.