### PR TITLE
fix(ipv6): always emit unicast-routing for mgmt IPv6

### DIFF
--- a/src/topogen/templates/_csr_mgmt_oob.jinja2
+++ b/src/topogen/templates/_csr_mgmt_oob.jinja2
@@ -12,10 +12,6 @@
 {%- set ipv4_dhcp = mgmt.ipv4_dhcp | default(false) %}
 {%- set ipv6_mode = mgmt.ipv6_mode | default(none) %}
 {%- set ipv6_only = ipv6_mode and not ipv4_dhcp %}
-{%- if ipv6_mode %}
-ipv6 unicast-routing
-!
-{%- endif %}
 {%- if mgmt.vrf %}
 vrf definition {{ mgmt.vrf }}
  rd 1:{{ mgmt.slot }}

--- a/src/topogen/templates/_iosv_mgmt_oob.jinja2
+++ b/src/topogen/templates/_iosv_mgmt_oob.jinja2
@@ -11,10 +11,6 @@
 {%- set ipv4_dhcp = mgmt.ipv4_dhcp | default(false) %}
 {%- set ipv6_mode = mgmt.ipv6_mode | default(none) %}
 {%- set ipv6_only = ipv6_mode and not ipv4_dhcp %}
-{%- if ipv6_mode %}
-ipv6 unicast-routing
-!
-{%- endif %}
 {%- if mgmt.vrf %}
 {%- if ipv6_mode %}
 vrf definition {{ mgmt.vrf }}

--- a/src/topogen/templates/csr1000v.jinja2
+++ b/src/topogen/templates/csr1000v.jinja2
@@ -19,6 +19,9 @@ ip subnet-zero
 ip domain lookup
 ip name-server {{ config.nameserver }}
 ip domain name {{ config.domainname }}
+{%- if mgmt and mgmt.enabled and mgmt.ipv6_mode %}
+ipv6 unicast-routing
+{%- endif %}
 crypto key generate rsa modulus 2048
 ip ssh version 2
 ip ssh server algorithm authentication password

--- a/src/topogen/templates/iosv.jinja2
+++ b/src/topogen/templates/iosv.jinja2
@@ -19,6 +19,9 @@ ip subnet-zero
 ip domain lookup
 ip name-server {{ config.nameserver }}
 ip domain name {{ config.domainname }}
+{%- if mgmt and mgmt.enabled and mgmt.ipv6_mode %}
+ipv6 unicast-routing
+{%- endif %}
 crypto key generate rsa modulus 2048
 ip ssh version 2
 ip ssh server algorithm authentication password


### PR DESCRIPTION
## Summary
Ensure ipv6 unicast-routing is always emitted whenever mgmt IPv6 is enabled on IOSv and CSRv.

## Changes
- emit ipv6 unicast-routing for all mgmt IPv6 modes
- move the command higher in generated config near global DNS/domain settings
- remove lower duplicate placement from OOB partials

## Files changed
- src/topogen/templates/iosv.jinja2
- src/topogen/templates/csr1000v.jinja2
- src/topogen/templates/_iosv_mgmt_oob.jinja2
- src/topogen/templates/_csr_mgmt_oob.jinja2

## Validation
- generated fresh offline YAML and confirmed ipv6 unicast-routing is present
- confirmed command placement is now in the higher global config section
- validated generated lab workflow during CSRv testing